### PR TITLE
Add context-aware WordGameEngine ctor

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/engine/WordGameEngine.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/WordGameEngine.java
@@ -30,6 +30,17 @@ public class WordGameEngine {
         this.currentGrid = generateGrid();
     }
 
+    /**
+     * Convenience constructor used mainly for unit tests. Loads the
+     * dictionary from the given {@link Context}'s assets using the
+     * built‑in "words.txt" file.
+     */
+    public WordGameEngine(Context context) {
+        this.random = new Random();
+        this.dictionary = loadDictionary(context);
+        this.currentGrid = generateGrid();
+    }
+
     public char[] generateGrid() {
         int total = GameConfig.TOTAL_LETTERS;            // e.g. 16
         int maxVowels = total / 2;                       // e.g. 8

--- a/app/src/test/java/com/gigamind/cognify/engine/WordGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/WordGameEngineTest.java
@@ -51,8 +51,9 @@ public class WordGameEngineTest {
         when(mockAssetManager.open(anyString()))
                 .thenReturn(dictionaryStream);
 
-        // Instantiate the engine (it will call loadDictionary → read our TEST_DICTIONARY)
-        wordGameEngine = new WordGameEngine(new HashSet<>());
+        // Instantiate the engine using the convenience constructor that loads
+        // the dictionary from the provided Context
+        wordGameEngine = new WordGameEngine(mockContext);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a constructor to WordGameEngine that loads its dictionary from an Android `Context`
- update unit test to use the new constructor

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841fb8fbcfc83328ce85ed37eb030a3