### PR TITLE
Fix scheduler delay to 24h

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/work/StreakNotificationScheduler.java
+++ b/app/src/main/java/com/gigamind/cognify/work/StreakNotificationScheduler.java
@@ -33,7 +33,7 @@ public class StreakNotificationScheduler {
         }
 
         long now = System.currentTimeMillis();
-        long twentyFourH = TimeUnit.HOURS.toMillis(1); // 1 hour for testing, but 24h in prod
+        long twentyFourH = TimeUnit.HOURS.toMillis(24); // 24 hours
         long runAt = lastMillis + twentyFourH;
         long delay = runAt - now;
         if (delay <= 0) {


### PR DESCRIPTION
## Summary
- use 24 hours instead of 1 hour when scheduling streak notifications

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841fe5566b483329ceb2c2c47b8006f