### PR TITLE
Add core unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 
     // -------- Mockito for JUnit Jupiter --------
     testImplementation("org.mockito:mockito-core:5.3.1")
@@ -79,4 +80,8 @@ dependencies {
 
     implementation("androidx.work:work-runtime-ktx:2.8.1")
     implementation("androidx.core:core-ktx:1.9.0")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/app/src/test/java/com/gigamind/cognify/InstantExecutorExtension.java
+++ b/app/src/test/java/com/gigamind/cognify/InstantExecutorExtension.java
@@ -1,0 +1,33 @@
+package com.gigamind.cognify;
+
+import androidx.arch.core.executor.ArchTaskExecutor;
+import androidx.arch.core.executor.TaskExecutor;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension that forces Architecture Components to execute tasks
+ * synchronously. This mirrors the behavior of InstantTaskExecutorRule from
+ * AndroidX test libraries but works with the Jupiter API.
+ */
+public class InstantExecutorExtension implements BeforeEachCallback, AfterEachCallback {
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        ArchTaskExecutor.getInstance().setDelegate(new TaskExecutor() {
+            @Override
+            public void executeOnDiskIO(Runnable runnable) { runnable.run(); }
+
+            @Override
+            public void postToMainThread(Runnable runnable) { runnable.run(); }
+
+            @Override
+            public boolean isMainThread() { return true; }
+        });
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        ArchTaskExecutor.getInstance().setDelegate(null);
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/engine/GameStateManagerTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/GameStateManagerTest.java
@@ -1,0 +1,59 @@
+package com.gigamind.cognify.engine;
+
+import com.gigamind.cognify.InstantExecutorExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(InstantExecutorExtension.class)
+public class GameStateManagerTest {
+    private GameStateManager manager;
+
+    @BeforeEach
+    void setUp() {
+        manager = GameStateManager.getInstance();
+        manager.reset();
+    }
+
+    @Test
+    void testStartAndAddScore() {
+        manager.startGame(1000L);
+        assertTrue(manager.isGameActive());
+        assertEquals(0, manager.getScore().getValue());
+        assertEquals(1000L, manager.getTimeRemaining().getValue());
+
+        manager.addScore(15);
+        assertEquals(15, manager.getScore().getValue());
+
+        manager.endGame();
+        assertFalse(manager.isGameActive());
+        manager.addScore(5);
+        assertEquals(15, manager.getScore().getValue(), "Score should not change after game ended");
+    }
+
+    @Test
+    void testUsedWordsAndTime() {
+        manager.startGame(5000L);
+        assertFalse(manager.isWordUsed("TEST"));
+        manager.addUsedWord("TEST");
+        assertTrue(manager.isWordUsed("TEST"));
+
+        manager.updateTimeRemaining(2500L);
+        assertEquals(2500L, manager.getTimeRemaining().getValue());
+    }
+
+    @Test
+    void testReset() {
+        manager.startGame(1000L);
+        manager.addScore(20);
+        manager.addUsedWord("HELLO");
+
+        manager.reset();
+        assertFalse(manager.isGameActive());
+        assertEquals(0, manager.getScore().getValue());
+        assertEquals(0L, manager.getTimeRemaining().getValue());
+        assertFalse(manager.isWordUsed("HELLO"));
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
@@ -1,0 +1,50 @@
+package com.gigamind.cognify.engine;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MathGameEngineTest {
+    private MathGameEngine engine;
+
+    @BeforeEach
+    void setUp() {
+        engine = new MathGameEngine();
+    }
+
+    @Test
+    void testGenerateQuestionAndOptions() {
+        engine.generateQuestion();
+
+        String q = engine.getCurrentQuestion();
+        assertNotNull(q, "Question should not be null");
+        assertTrue(q.matches("\\d+ \\+ \\d+ = \\?"), "Question format invalid: " + q);
+
+        int answer = engine.getCurrentAnswer();
+        assertTrue(answer > 1, "Answer should be at least 2");
+
+        List<Integer> options = engine.getOptions();
+        assertEquals(4, options.size(), "There should be four options");
+
+        Set<Integer> unique = new HashSet<>(options);
+        assertEquals(4, unique.size(), "Options should be unique");
+        assertTrue(options.contains(answer), "Options should contain the correct answer");
+    }
+
+    @Test
+    void testCheckAnswerAndScore() {
+        engine.generateQuestion();
+        int correct = engine.getCurrentAnswer();
+
+        assertTrue(engine.checkAnswer(correct));
+        assertFalse(engine.checkAnswer(correct + 1));
+
+        assertEquals(10, engine.getScore(true));
+        assertEquals(0, engine.getScore(false));
+    }
+}


### PR DESCRIPTION
## Summary
- test `MathGameEngine` logic
- test `GameStateManager` using a small JUnit 5 extension
- enable JUnit5 in Gradle and add runtime engine

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841fec5734c83329eadb198829ed25b