### PR TITLE
Add new unit tests

### DIFF
--- a/app/src/test/java/com/gigamind/cognify/model/WordGameStateTest.java
+++ b/app/src/test/java/com/gigamind/cognify/model/WordGameStateTest.java
@@ -1,0 +1,48 @@
+import com.gigamind.cognify.model.WordGameState;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class WordGameStateTest {
+
+    @Test
+    void testBuilderSetsAllFieldsAndIsImmutable() {
+        List<String> words = new ArrayList<>(Arrays.asList("HELLO", "WORLD"));
+        char[] letters = new char[] {'A','B','C','D'};
+
+        WordGameState state = new WordGameState.Builder()
+                .score(42)
+                .timeRemaining(1234L)
+                .currentWord("TEST")
+                .foundWords(words)
+                .letters(letters)
+                .isGameActive(true)
+                .build();
+
+        // modify originals after building
+        words.add("MUTATE");
+        letters[0] = 'Z';
+
+        // verify stored values remain unchanged
+        assertEquals(42, state.getScore());
+        assertEquals(1234L, state.getTimeRemaining());
+        assertEquals("TEST", state.getCurrentWord());
+        assertEquals(Arrays.asList("HELLO", "WORLD"), state.getFoundWords());
+        assertArrayEquals(new char[] {'A','B','C','D'}, state.getLetters());
+        assertTrue(state.isGameActive());
+    }
+
+    @Test
+    void testBuilderDefaultValues() {
+        WordGameState state = new WordGameState.Builder().build();
+        assertEquals(0, state.getScore());
+        assertEquals(0L, state.getTimeRemaining());
+        assertEquals("", state.getCurrentWord());
+        assertTrue(state.getFoundWords().isEmpty());
+        assertEquals(16, state.getLetters().length);
+        assertFalse(state.isGameActive());
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/util/GameConfigTest.java
+++ b/app/src/test/java/com/gigamind/cognify/util/GameConfigTest.java
@@ -1,0 +1,20 @@
+import com.gigamind.cognify.util.GameConfig;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GameConfigTest {
+
+    @Test
+    void testWordGameSettings() {
+        assertEquals(4, GameConfig.GRID_SIZE);
+        assertEquals(16, GameConfig.TOTAL_LETTERS);
+        assertTrue(GameConfig.MIN_WORD_LENGTH >= 3);
+    }
+
+    @Test
+    void testScoringConstants() {
+        assertTrue(GameConfig.BASE_SCORE > 0);
+        assertTrue(GameConfig.LENGTH_BONUS > 0);
+        assertTrue(GameConfig.COMPLEXITY_BONUS > 0);
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/util/UserFieldsTest.java
+++ b/app/src/test/java/com/gigamind/cognify/util/UserFieldsTest.java
@@ -1,0 +1,14 @@
+import com.gigamind.cognify.util.UserFields;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UserFieldsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"WordDash", "QuickMath", "Chess"})
+    void testLastGameScoreField(String type) {
+        String expected = "last" + type + "Score";
+        assertEquals(expected, UserFields.lastGameScoreField(type));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for WordGameState builder behavior
- add tests for UserFields helper
- add tests validating GameConfig constants

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6842033258008332a2df0b61a7b4a8bb