### PR TITLE
Add additional unit tests

### DIFF
--- a/app/src/test/java/com/gigamind/cognify/exception/GameExceptionTest.java
+++ b/app/src/test/java/com/gigamind/cognify/exception/GameExceptionTest.java
@@ -1,0 +1,24 @@
+package com.gigamind.cognify.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GameExceptionTest {
+    @Test
+    void constructorSetsMessageAndCode() {
+        GameException ex = new GameException(GameException.ErrorCode.INVALID_WORD_LENGTH,
+                "Too short");
+        assertEquals(GameException.ErrorCode.INVALID_WORD_LENGTH, ex.getErrorCode());
+        assertEquals("Too short", ex.getMessage());
+    }
+
+    @Test
+    void constructorWithCausePreservesCause() {
+        Throwable cause = new IllegalArgumentException("bad");
+        GameException ex = new GameException(GameException.ErrorCode.WORD_ALREADY_USED,
+                "Used", cause);
+        assertEquals(cause, ex.getCause());
+        assertEquals(GameException.ErrorCode.WORD_ALREADY_USED, ex.getErrorCode());
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/ui/leaderboard/LeaderboardItemTest.java
+++ b/app/src/test/java/com/gigamind/cognify/ui/leaderboard/LeaderboardItemTest.java
@@ -1,0 +1,15 @@
+package com.gigamind.cognify.ui.leaderboard;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LeaderboardItemTest {
+    @ParameterizedTest
+    @CsvSource({"50,bronze", "1000,silver", "1500,silver", "2500,gold"})
+    void badgeTypeMatchesXpThreshold(int xp, String expected) {
+        LeaderboardItem item = new LeaderboardItem("id", "name", xp, "US");
+        assertEquals(expected, item.getBadgeType());
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/util/OnboardingItemTest.java
+++ b/app/src/test/java/com/gigamind/cognify/util/OnboardingItemTest.java
@@ -1,0 +1,15 @@
+package com.gigamind.cognify.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OnboardingItemTest {
+    @Test
+    void fieldsAreStoredCorrectly() {
+        OnboardingItem item = new OnboardingItem(1, "Title", "Desc");
+        assertEquals(1, item.imageResId);
+        assertEquals("Title", item.title);
+        assertEquals("Desc", item.description);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for GameException
- add tests for OnboardingItem
- add tests for LeaderboardItem badge logic

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842043bab40833294a13a31d6b74f22