### PR TITLE
Refactor word scoring with strategy pattern

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/engine/scoring/DefaultWordScoreStrategy.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/scoring/DefaultWordScoreStrategy.java
@@ -1,0 +1,31 @@
+package com.gigamind.cognify.engine.scoring;
+
+import com.gigamind.cognify.util.GameConfig;
+
+/**
+ * Default scoring rules for the word game.
+ */
+public class DefaultWordScoreStrategy implements ScoreStrategy {
+    @Override
+    public int calculateScore(String word) {
+        if (word == null || word.length() < GameConfig.MIN_WORD_LENGTH) {
+            return 0;
+        }
+
+        int score = GameConfig.BASE_SCORE;
+
+        // Length bonus
+        score += (word.length() - GameConfig.MIN_WORD_LENGTH) * GameConfig.LENGTH_BONUS;
+
+        // Complexity bonus for less common letters
+        for (char c : word.toCharArray()) {
+            if ("JQXZ".indexOf(c) >= 0) {
+                score += GameConfig.COMPLEXITY_BONUS;
+            } else if ("KWVY".indexOf(c) >= 0) {
+                score += GameConfig.COMPLEXITY_BONUS / 2;
+            }
+        }
+
+        return score;
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/engine/scoring/ScoreStrategy.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/scoring/ScoreStrategy.java
@@ -1,0 +1,14 @@
+package com.gigamind.cognify.engine.scoring;
+
+/**
+ * Strategy interface for word score calculation.
+ */
+public interface ScoreStrategy {
+    /**
+     * Calculates the score for a given word. Implementations decide the rules.
+     *
+     * @param word the word to score
+     * @return the calculated score
+     */
+    int calculateScore(String word);
+}


### PR DESCRIPTION
## Summary
- introduce `ScoreStrategy` and `DefaultWordScoreStrategy`
- refactor `WordGameEngine` to delegate score calculation to a strategy

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68420706c7708332a1e80d136f25dc0e