### PR TITLE
Introduce enums for analytics

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/analytics/ResponseTimeBucket.java
+++ b/app/src/main/java/com/gigamind/cognify/analytics/ResponseTimeBucket.java
@@ -1,0 +1,33 @@
+package com.gigamind.cognify.analytics;
+
+/**
+ * Buckets representing how quickly a player responded.
+ */
+public enum ResponseTimeBucket {
+    FAST("fast"),
+    MEDIUM("medium"),
+    SLOW("slow");
+
+    private final String label;
+
+    ResponseTimeBucket(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    /**
+     * Returns the corresponding bucket for the given elapsed time.
+     */
+    public static ResponseTimeBucket fromTime(long millis) {
+        if (millis < 3000) {
+            return FAST;
+        }
+        if (millis < 6000) {
+            return MEDIUM;
+        }
+        return SLOW;
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -11,6 +11,7 @@ import com.gigamind.cognify.engine.MathGameEngine;
 import com.gigamind.cognify.util.Constants;
 import com.google.android.material.button.MaterialButton;
 import com.gigamind.cognify.analytics.GameAnalytics;
+import com.gigamind.cognify.util.GameType;
 
 import java.util.List;
 
@@ -32,7 +33,7 @@ public class QuickMathActivity extends AppCompatActivity {
 
         analytics = GameAnalytics.getInstance(this);
         analytics.logScreenView("quick_math_game");
-        analytics.logGameStart("MATH");
+        analytics.logGameStart(GameType.MATH);
 
         // Initialize views
         scoreText = findViewById(R.id.scoreText);
@@ -106,7 +107,7 @@ public class QuickMathActivity extends AppCompatActivity {
     }
 
     private void endGame() {
-        analytics.logGameEnd("MATH", 
+        analytics.logGameEnd(GameType.MATH,
             currentScore,
             questionCount,
             true);
@@ -122,7 +123,7 @@ public class QuickMathActivity extends AppCompatActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        analytics.logGameEnd("MATH", 
+        analytics.logGameEnd(GameType.MATH,
             currentScore,
             questionCount,
             false);

--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -22,6 +22,7 @@ import com.gigamind.cognify.engine.GameStateManager;
 import com.gigamind.cognify.engine.WordGameEngine;
 import com.gigamind.cognify.util.Constants;
 import com.gigamind.cognify.util.GameConfig;
+import com.gigamind.cognify.util.GameType;
 import com.google.android.flexbox.FlexDirection;
 import com.google.android.flexbox.FlexWrap;
 import com.google.android.flexbox.FlexboxLayoutManager;
@@ -57,7 +58,7 @@ public class WordDashActivity extends AppCompatActivity {
 
         analytics = GameAnalytics.getInstance(this);
         analytics.logScreenView("word_dash_game");
-        analytics.logGameStart("WORD");
+        analytics.logGameStart(GameType.WORD);
         
         // 1) Bind all views and set up UI scaffolding that does NOT use gameEngine yet
         initializeViews();
@@ -301,7 +302,7 @@ public class WordDashActivity extends AppCompatActivity {
 
     private void endGame() {
         gameStateManager.endGame();
-        analytics.logGameEnd("WORD", 
+        analytics.logGameEnd(GameType.WORD,
             gameStateManager.getScore().getValue(),
             (int)(GameConfig.WORD_DASH_DURATION_MS / 1000),
             true);
@@ -355,7 +356,7 @@ public class WordDashActivity extends AppCompatActivity {
         super.onPause();
         if (countDownTimer != null) {
             countDownTimer.cancel();
-            analytics.logGameEnd("WORD", 
+            analytics.logGameEnd(GameType.WORD,
                 gameStateManager.getScore().getValue(),
                 (int)(GameConfig.WORD_DASH_DURATION_MS / 1000),
                 false);

--- a/app/src/main/java/com/gigamind/cognify/util/GameType.java
+++ b/app/src/main/java/com/gigamind/cognify/util/GameType.java
@@ -1,0 +1,36 @@
+package com.gigamind.cognify.util;
+
+/**
+ * Enum representing the different game types available in the app.
+ */
+public enum GameType {
+    WORD("WORD"),
+    MATH("MATH");
+
+    private final String id;
+
+    GameType(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the identifier string used for analytics and intents.
+     */
+    public String id() {
+        return id;
+    }
+
+    /**
+     * Converts a string identifier back into a {@link GameType}.
+     *
+     * @throws IllegalArgumentException if the id does not match any type
+     */
+    public static GameType fromId(String id) {
+        for (GameType type : values()) {
+            if (type.id.equalsIgnoreCase(id)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown game type: " + id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `GameType` enum
- add `ResponseTimeBucket` enum
- refactor `GameAnalytics` to use enums and typed collections
- update WordDash and QuickMath activities to use new enum API

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68420aab90b883328d4c195513ce9b0b