### PR TITLE
Fix Word Dash duration bug

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/util/GameConfig.java
+++ b/app/src/main/java/com/gigamind/cognify/util/GameConfig.java
@@ -2,7 +2,8 @@ package com.gigamind.cognify.util;
 
 public final class GameConfig {
     // Game durations
-    public static final long WORD_DASH_DURATION_MS = 15_000; // 60 seconds
+    // Duration for the Word Dash game in milliseconds (60 seconds)
+    public static final long WORD_DASH_DURATION_MS = 60_000;
     public static final long QUICK_MATH_DURATION_MS = 45_000; // 45 seconds
 
     // Word game settings


### PR DESCRIPTION
## Summary
- correct the duration constant for Word Dash to last 60 seconds

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68420ffe81f4833281787618b7f9b65a