### PR TITLE
Centralize frequent strings

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
+++ b/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
@@ -31,8 +31,6 @@ public class CognifyApplication extends Application {
     private static final String TAG = "CognifyApplication";
     private UserRepository userRepo;
     private com.google.firebase.firestore.ListenerRegistration listenerRegistration;
-    private static final String NOTIFICATION_PREF = "notification_preferences";
-    private static final String KEY_NOTIFICATION_ENABLED = "notifications_enabled";
 
     @Override
     public void onCreate() {
@@ -58,8 +56,8 @@ public class CognifyApplication extends Application {
                     Log.d(TAG, "Firestore → SharedPrefs listener fired. Scheduling Worker now.");
                     
                     // Only schedule if notifications are enabled
-                    SharedPreferences prefs = getSharedPreferences(NOTIFICATION_PREF, MODE_PRIVATE);
-                    if (prefs.getBoolean(KEY_NOTIFICATION_ENABLED, true)) {
+                    SharedPreferences prefs = getSharedPreferences(Constants.PREF_NOTIFICATION, MODE_PRIVATE);
+                    if (prefs.getBoolean(Constants.PREF_NOTIFICATION_ENABLED, true)) {
                         StreakNotificationScheduler.scheduleFromSharedPrefs(
                                 FirebaseAuth.getInstance().getCurrentUser().getUid(),
                                 getApplicationContext()
@@ -87,24 +85,24 @@ public class CognifyApplication extends Application {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
                     != PackageManager.PERMISSION_GRANTED) {
                 // Permission not granted, save this state
-                getSharedPreferences(NOTIFICATION_PREF, MODE_PRIVATE)
+                getSharedPreferences(Constants.PREF_NOTIFICATION, MODE_PRIVATE)
                     .edit()
-                    .putBoolean(KEY_NOTIFICATION_ENABLED, false)
+                    .putBoolean(Constants.PREF_NOTIFICATION_ENABLED, false)
                     .apply();
                 Log.d(TAG, "Notification permission not granted on Android 13+");
             } else {
                 // Permission granted
-                getSharedPreferences(NOTIFICATION_PREF, MODE_PRIVATE)
+                getSharedPreferences(Constants.PREF_NOTIFICATION, MODE_PRIVATE)
                     .edit()
-                    .putBoolean(KEY_NOTIFICATION_ENABLED, true)
+                    .putBoolean(Constants.PREF_NOTIFICATION_ENABLED, true)
                     .apply();
                 Log.d(TAG, "Notification permission granted on Android 13+");
             }
         } else {
             // For Android 12 and below, notifications are enabled by default
-            getSharedPreferences(NOTIFICATION_PREF, MODE_PRIVATE)
+            getSharedPreferences(Constants.PREF_NOTIFICATION, MODE_PRIVATE)
                 .edit()
-                .putBoolean(KEY_NOTIFICATION_ENABLED, true)
+                .putBoolean(Constants.PREF_NOTIFICATION_ENABLED, true)
                 .apply();
             Log.d(TAG, "Notification enabled by default (Android 12 or below)");
         }

--- a/app/src/main/java/com/gigamind/cognify/data/repository/UserRepository.java
+++ b/app/src/main/java/com/gigamind/cognify/data/repository/UserRepository.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 
 import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.gigamind.cognify.util.UserFields;
+import com.gigamind.cognify.util.Constants;
 import com.gigamind.cognify.work.StreakNotificationScheduler;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -36,7 +37,7 @@ public class UserRepository {
     public static final String KEY_CURRENT_STREAK = UserFields.FIELD_CURRENT_STREAK;
     public static final String KEY_TOTAL_XP = UserFields.FIELD_TOTAL_XP;
     public static final String KEY_PERSONAL_BEST_XP = UserFields.FIELD_PERSONAL_BEST_XP;
-    private static final String PREFS_NAME = "GamePrefs";
+    private static final String PREFS_NAME = Constants.PREFS_NAME;
     private final SharedPreferences prefs;
     private final FirebaseService firebaseService;
     private Context context;

--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -37,6 +37,7 @@ import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.GoogleAuthProvider;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.gigamind.cognify.util.Constants;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -50,9 +51,6 @@ import java.util.Map;
  */
 public class OnboardingActivity extends AppCompatActivity {
     private static final int RC_SIGN_IN = 9001;
-    private static final String PREFS_NAME = "GamePrefs";
-    private static final String PREF_ASKED_NOTIFICATIONS = "asked_for_notifications";
-    private static final String KEY_IS_GUEST = "is_guest_mode";
 
     private ActivityOnboardingBinding binding;
     private GoogleSignInClient googleSignInClient;
@@ -70,7 +68,7 @@ public class OnboardingActivity extends AppCompatActivity {
         binding = ActivityOnboardingBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+        prefs = getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
 
         firebaseAuth = FirebaseAuth.getInstance();
         firestore = FirebaseFirestore.getInstance();
@@ -108,7 +106,7 @@ public class OnboardingActivity extends AppCompatActivity {
                             } else {
                                 // User denied. We'll treat this as "No thanks" and stop asking again.
                                 prefs.edit()
-                                        .putBoolean(PREF_ASKED_NOTIFICATIONS, true)
+                                        .putBoolean(Constants.PREF_ASKED_NOTIFICATIONS, true)
                                         .apply();
                                 Toast.makeText(this, "Notifications disabled. You may lose your streak if you don't play.", Toast.LENGTH_SHORT).show();
                             }
@@ -127,7 +125,7 @@ public class OnboardingActivity extends AppCompatActivity {
         }
 
         // If user already tapped "No thanks," we don't ask again.
-        boolean alreadyAsked = prefs.getBoolean(PREF_ASKED_NOTIFICATIONS, false);
+        boolean alreadyAsked = prefs.getBoolean(Constants.PREF_ASKED_NOTIFICATIONS, false);
         if (alreadyAsked) {
             return;
         }
@@ -150,7 +148,7 @@ public class OnboardingActivity extends AppCompatActivity {
                 .setNegativeButton("No thanks", (dialog, which) -> {
                     // User does not want notifications: record that and close dialog
                     prefs.edit()
-                            .putBoolean(PREF_ASKED_NOTIFICATIONS, true)
+                            .putBoolean(Constants.PREF_ASKED_NOTIFICATIONS, true)
                             .apply();
                     dialog.dismiss();
                 })
@@ -238,7 +236,7 @@ public class OnboardingActivity extends AppCompatActivity {
 
     private void continueAsGuest() {
         SharedPreferences.Editor editor = prefs.edit();
-        editor.putBoolean(KEY_IS_GUEST, true);
+        editor.putBoolean(Constants.PREF_IS_GUEST, true);
         editor.putInt(UserRepository.KEY_CURRENT_STREAK, 0);
         editor.putInt(UserRepository.KEY_TOTAL_XP, 0);
         editor.putString(UserRepository.KEY_LAST_PLAYED_DATE, "");

--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -32,7 +32,7 @@ public class QuickMathActivity extends AppCompatActivity {
         setContentView(R.layout.activity_quick_math);
 
         analytics = GameAnalytics.getInstance(this);
-        analytics.logScreenView("quick_math_game");
+        analytics.logScreenView(Constants.ANALYTICS_SCREEN_QUICK_MATH);
         analytics.logGameStart(GameType.MATH);
 
         // Initialize views

--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -18,6 +18,7 @@ import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.LinearGradient;
 import android.graphics.Shader;
+import com.gigamind.cognify.util.Constants;
 import android.media.MediaPlayer;
 import android.os.Bundle;
 import android.os.Handler;
@@ -69,7 +70,7 @@ public class ResultActivity extends AppCompatActivity {
         setContentView(R.layout.activity_result);
 
         analytics = GameAnalytics.getInstance(this);
-        analytics.logScreenView("result_screen");
+        analytics.logScreenView(Constants.ANALYTICS_SCREEN_RESULT);
 
         initializeViews();
 
@@ -78,7 +79,7 @@ public class ResultActivity extends AppCompatActivity {
             dingSound = MediaPlayer.create(this, R.raw.lesson_complete);
         }
 
-        prefs          = getSharedPreferences("GamePrefs", MODE_PRIVATE);
+        prefs          = getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
         userRepository = new UserRepository(this);
         firebaseUser   = FirebaseAuth.getInstance().getCurrentUser();
 

--- a/app/src/main/java/com/gigamind/cognify/ui/SplashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/SplashActivity.java
@@ -9,6 +9,7 @@ import android.os.Looper;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.gigamind.cognify.databinding.ActivitySplashBinding;
+import com.gigamind.cognify.util.Constants;
 
 public class SplashActivity extends AppCompatActivity {
     private ActivitySplashBinding binding;
@@ -21,8 +22,8 @@ public class SplashActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         // Check if first time launch
-        SharedPreferences prefs = getSharedPreferences("AppPrefs", MODE_PRIVATE);
-        boolean isFirstLaunch = prefs.getBoolean("isFirstLaunch", true);
+        SharedPreferences prefs = getSharedPreferences(Constants.PREF_APP, MODE_PRIVATE);
+        boolean isFirstLaunch = prefs.getBoolean(Constants.PREF_IS_FIRST_LAUNCH, true);
 
         new Handler(Looper.getMainLooper()).postDelayed(() -> {
             Intent intent;
@@ -30,7 +31,7 @@ public class SplashActivity extends AppCompatActivity {
                 // First time launch - go to onboarding
                 intent = new Intent(SplashActivity.this, OnboardingActivity.class);
                 // Set first launch to false
-                prefs.edit().putBoolean("isFirstLaunch", false).apply();
+                prefs.edit().putBoolean(Constants.PREF_IS_FIRST_LAUNCH, false).apply();
             } else {
                 // Regular launch - go to main activity
                 intent = new Intent(SplashActivity.this, MainActivity.class);

--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -57,7 +57,7 @@ public class WordDashActivity extends AppCompatActivity {
         setContentView(R.layout.activity_word_dash);
 
         analytics = GameAnalytics.getInstance(this);
-        analytics.logScreenView("word_dash_game");
+        analytics.logScreenView(Constants.ANALYTICS_SCREEN_WORD_DASH);
         analytics.logGameStart(GameType.WORD);
         
         // 1) Bind all views and set up UI scaffolding that does NOT use gameEngine yet

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -23,6 +23,7 @@ import com.gigamind.cognify.data.repository.UserRepository;
 import com.gigamind.cognify.databinding.FragmentHomeBinding;
 import com.gigamind.cognify.ui.QuickMathActivity;
 import com.gigamind.cognify.ui.WordDashActivity;
+import com.gigamind.cognify.util.Constants;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.auth.FirebaseAuth;
@@ -72,7 +73,7 @@ public class HomeFragment extends Fragment {
         initializeViews();
 
         // Initialize SharedPreferences and UserRepository
-        prefs = requireContext().getSharedPreferences("GamePrefs", MODE_PRIVATE);
+        prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
         userRepository = new UserRepository(requireContext());
 
         // Check signed-in user

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -17,6 +17,7 @@ import com.gigamind.cognify.R;
 import com.gigamind.cognify.data.repository.UserRepository;
 import com.gigamind.cognify.databinding.FragmentSettingsBinding;
 import com.gigamind.cognify.ui.OnboardingActivity;
+import com.gigamind.cognify.util.Constants;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.firebase.auth.FirebaseAuth;
 
@@ -35,7 +36,7 @@ public class SettingsFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        prefs = requireActivity().getSharedPreferences("AppPrefs", 0);
+        prefs = requireActivity().getSharedPreferences(Constants.PREF_APP, 0);
         setupPreferences();
         setupButtons();
     }
@@ -101,7 +102,7 @@ public class SettingsFragment extends Fragment {
                         .setPositiveButton("Yes, Sign Out", (dialog, which) -> {
                             // Clear only streak/xp/personal‐best from prefs:
                             SharedPreferences prefs = requireActivity()
-                                    .getSharedPreferences("GamePrefs", MODE_PRIVATE);
+                                    .getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
                             prefs.edit()
                                     .remove(UserRepository.KEY_LAST_PLAYED_DATE)
                                     .remove(UserRepository.KEY_LAST_PLAYED_TS)

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -21,6 +21,7 @@ import com.gigamind.cognify.data.repository.UserRepository;
 import com.gigamind.cognify.databinding.FragmentWordDashBinding;
 import com.gigamind.cognify.ui.QuickMathActivity;
 import com.gigamind.cognify.ui.WordDashActivity;
+import com.gigamind.cognify.util.Constants;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.button.MaterialButton;
 import com.google.firebase.auth.FirebaseAuth;
@@ -66,7 +67,7 @@ public class WordDashFragment extends Fragment {
         initializeViews();
 
         // Initialize SharedPreferences and UserRepository
-        prefs = requireContext().getSharedPreferences("GamePrefs", MODE_PRIVATE);
+        prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
         userRepository = new UserRepository(requireContext());
 
         // Check signed-in user

--- a/app/src/main/java/com/gigamind/cognify/util/Constants.java
+++ b/app/src/main/java/com/gigamind/cognify/util/Constants.java
@@ -12,4 +12,18 @@ public class Constants {
     // XP bonuses
     public static final int BONUS_NEW_PB       = 20; // extra XP if player beats PB
     public static final int BONUS_STREAK_PER_DAY = 10;
+
+    // SharedPreferences names & keys
+    public static final String PREFS_NAME = "GamePrefs";
+    public static final String PREF_APP = "AppPrefs";
+    public static final String PREF_IS_FIRST_LAUNCH = "isFirstLaunch";
+    public static final String PREF_ASKED_NOTIFICATIONS = "asked_for_notifications";
+    public static final String PREF_IS_GUEST = "is_guest_mode";
+    public static final String PREF_NOTIFICATION = "notification_preferences";
+    public static final String PREF_NOTIFICATION_ENABLED = "notifications_enabled";
+
+    // Analytics screen names
+    public static final String ANALYTICS_SCREEN_RESULT = "result_screen";
+    public static final String ANALYTICS_SCREEN_WORD_DASH = "word_dash_game";
+    public static final String ANALYTICS_SCREEN_QUICK_MATH = "quick_math_game";
 }


### PR DESCRIPTION
## Summary
- add new preference and analytics string constants
- reference those constants across activities and fragments

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842102ef4c48332ab0d5b08e1652bf5