### PR TITLE
Add new unit tests for utility classes

### DIFF
--- a/app/src/test/java/com/gigamind/cognify/analytics/ResponseTimeBucketTest.java
+++ b/app/src/test/java/com/gigamind/cognify/analytics/ResponseTimeBucketTest.java
@@ -1,0 +1,22 @@
+package com.gigamind.cognify.analytics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ResponseTimeBucketTest {
+
+    @Test
+    void testLabels() {
+        assertEquals("fast", ResponseTimeBucket.FAST.label());
+        assertEquals("medium", ResponseTimeBucket.MEDIUM.label());
+        assertEquals("slow", ResponseTimeBucket.SLOW.label());
+    }
+
+    @Test
+    void testFromTime() {
+        assertEquals(ResponseTimeBucket.FAST, ResponseTimeBucket.fromTime(1000));
+        assertEquals(ResponseTimeBucket.MEDIUM, ResponseTimeBucket.fromTime(4000));
+        assertEquals(ResponseTimeBucket.SLOW, ResponseTimeBucket.fromTime(7000));
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/engine/scoring/DefaultWordScoreStrategyTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/scoring/DefaultWordScoreStrategyTest.java
@@ -1,0 +1,28 @@
+package com.gigamind.cognify.engine.scoring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DefaultWordScoreStrategyTest {
+
+    @Test
+    void testCalculateScoreBasicWord() {
+        ScoreStrategy strategy = new DefaultWordScoreStrategy();
+        assertEquals(10, strategy.calculateScore("CAT"));
+    }
+
+    @Test
+    void testCalculateScoreComplexWord() {
+        ScoreStrategy strategy = new DefaultWordScoreStrategy();
+        // word length 5 => base 10 + (5-3)*5 = 20; letters J and X add 8 each
+        assertEquals(36, strategy.calculateScore("JAXON"));
+    }
+
+    @Test
+    void testInvalidWordReturnsZero() {
+        ScoreStrategy strategy = new DefaultWordScoreStrategy();
+        assertEquals(0, strategy.calculateScore("hi"));
+        assertEquals(0, strategy.calculateScore(null));
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/util/ConstantsTest.java
+++ b/app/src/test/java/com/gigamind/cognify/util/ConstantsTest.java
@@ -1,0 +1,20 @@
+package com.gigamind.cognify.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConstantsTest {
+
+    @Test
+    void testIntentConstants() {
+        assertEquals("score", Constants.INTENT_SCORE);
+        assertEquals("time", Constants.INTENT_TIME);
+    }
+
+    @Test
+    void testPreferences() {
+        assertNotNull(Constants.PREFS_NAME);
+        assertNotNull(Constants.PREF_APP);
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/util/GameTypeTest.java
+++ b/app/src/test/java/com/gigamind/cognify/util/GameTypeTest.java
@@ -1,0 +1,21 @@
+package com.gigamind.cognify.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GameTypeTest {
+
+    @Test
+    void testId() {
+        assertEquals("WORD", GameType.WORD.id());
+        assertEquals("MATH", GameType.MATH.id());
+    }
+
+    @Test
+    void testFromId() {
+        assertEquals(GameType.WORD, GameType.fromId("WORD"));
+        assertEquals(GameType.MATH, GameType.fromId("math"));
+        assertThrows(IllegalArgumentException.class, () -> GameType.fromId("other"));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `ResponseTimeBucket`
- test `DefaultWordScoreStrategy` scoring
- verify `GameType` enum helpers
- basic checks for constants

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842120d444883328285aabcd6876c6e