### PR TITLE
Add edge case tests

### DIFF
--- a/app/src/test/java/com/gigamind/cognify/analytics/ResponseTimeBucketTest.java
+++ b/app/src/test/java/com/gigamind/cognify/analytics/ResponseTimeBucketTest.java
@@ -19,4 +19,10 @@ public class ResponseTimeBucketTest {
         assertEquals(ResponseTimeBucket.MEDIUM, ResponseTimeBucket.fromTime(4000));
         assertEquals(ResponseTimeBucket.SLOW, ResponseTimeBucket.fromTime(7000));
     }
+
+    @Test
+    void testFromTimeBoundaries() {
+        assertEquals(ResponseTimeBucket.MEDIUM, ResponseTimeBucket.fromTime(3000));
+        assertEquals(ResponseTimeBucket.SLOW, ResponseTimeBucket.fromTime(6000));
+    }
 }

--- a/app/src/test/java/com/gigamind/cognify/engine/GameStateManagerTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/GameStateManagerTest.java
@@ -56,4 +56,18 @@ public class GameStateManagerTest {
         assertEquals(0L, manager.getTimeRemaining().getValue());
         assertFalse(manager.isWordUsed("HELLO"));
     }
+
+    @Test
+    void testStartGameTwiceResetsState() {
+        manager.startGame(1000L);
+        manager.addScore(10);
+        manager.addUsedWord("WORD");
+
+        manager.startGame(2000L);
+
+        assertTrue(manager.isGameActive());
+        assertEquals(0, manager.getScore().getValue());
+        assertFalse(manager.isWordUsed("WORD"));
+        assertEquals(2000L, manager.getTimeRemaining().getValue());
+    }
 }

--- a/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
@@ -37,6 +37,17 @@ public class MathGameEngineTest {
     }
 
     @Test
+    void testOptionsWithinRange() {
+        engine.generateQuestion();
+        int answer = engine.getCurrentAnswer();
+        for (int option : engine.getOptions()) {
+            assertTrue(option > 0, "Options should be positive");
+            assertTrue(Math.abs(option - answer) <= 3,
+                    "Option out of range from correct answer");
+        }
+    }
+
+    @Test
     void testCheckAnswerAndScore() {
         engine.generateQuestion();
         int correct = engine.getCurrentAnswer();

--- a/app/src/test/java/com/gigamind/cognify/engine/WordGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/WordGameEngineTest.java
@@ -50,6 +50,14 @@ public class WordGameEngineTest {
     }
 
     @Test
+    void testIsValidWordEdgeCases() {
+        assertFalse(engine.isValidWord(""), "Empty string should be invalid");
+        assertFalse(engine.isValidWord("   "), "Whitespace-only word should be invalid");
+        assertFalse(engine.isValidWord("123"), "Numeric word should be invalid");
+        assertFalse(engine.isValidWord("CAT "), "Word with trailing space should be invalid");
+    }
+
+    @Test
     void testCalculateScore() {
         // Base score 10 plus length bonus (3 letters -> 0) = 10
         assertEquals(10, engine.calculateScore("CAT"));

--- a/app/src/test/java/com/gigamind/cognify/ui/leaderboard/LeaderboardItemTest.java
+++ b/app/src/test/java/com/gigamind/cognify/ui/leaderboard/LeaderboardItemTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class LeaderboardItemTest {
     @ParameterizedTest
-    @CsvSource({"50,bronze", "1000,silver", "1500,silver", "2500,gold"})
+    @CsvSource({"50,bronze", "0,bronze", "-10,bronze", "1000,silver", "1500,silver", "2000,gold", "2500,gold"})
     void badgeTypeMatchesXpThreshold(int xp, String expected) {
         LeaderboardItem item = new LeaderboardItem("id", "name", xp, "US");
         assertEquals(expected, item.getBadgeType());


### PR DESCRIPTION
## Summary
- cover more edge cases for word validation
- ensure math options stay within range
- verify repeated start resets state
- check response time boundaries
- expand leaderboard badge cases

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68421313a2948332a117a295f62e00da