### PR TITLE
Add basic exception handling

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
+++ b/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
@@ -37,6 +37,9 @@ public class CognifyApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
+        Thread.setDefaultUncaughtExceptionHandler((t, e) ->
+                Log.e(TAG, "Uncaught exception in thread " + t.getName(), e));
+
         // (1) Initialize Firebase
         FirebaseApp.initializeApp(this);
 

--- a/app/src/main/java/com/gigamind/cognify/engine/DictionaryProvider.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/DictionaryProvider.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -51,7 +52,7 @@ public class DictionaryProvider {
                     }
                 }
             } catch (IOException e) {
-                // swallow or log
+                Log.e("DictionaryProvider", "Error preloading dictionary", e);
             }
             sDictionary = dict;
             sIsLoading = false;
@@ -102,7 +103,7 @@ public class DictionaryProvider {
                     }
                     reader.close();
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    Log.e("DictionaryProvider", "Error loading dictionary", e);
                 }
                 // freeze into unmodifiable set
                 sDictionary = Collections.unmodifiableSet(dict);

--- a/app/src/main/java/com/gigamind/cognify/engine/WordGameEngine.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/WordGameEngine.java
@@ -3,6 +3,8 @@ package com.gigamind.cognify.engine;
 import android.content.Context;
 import android.content.res.AssetManager;
 
+import com.gigamind.cognify.exception.GameException;
+
 import com.gigamind.cognify.util.GameConfig;
 
 import java.io.BufferedReader;
@@ -117,7 +119,11 @@ public class WordGameEngine {
             }
             reader.close();
         } catch (IOException e) {
-            throw new RuntimeException("Failed to load dictionary: " + e.getMessage());
+            throw new GameException(
+                    GameException.ErrorCode.DICTIONARY_LOAD_ERROR,
+                    "Failed to load dictionary",
+                    e
+            );
         }
         return words;
     }


### PR DESCRIPTION
## Summary
- add uncaught exception logging in `CognifyApplication`
- log dictionary loading errors
- throw `GameException` when word dictionary fails to load

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842163820108332b26de832739d0f9f