### PR TITLE
Add global exception logger

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
+++ b/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.util.Log;
+import com.gigamind.cognify.util.ExceptionLogger;
 
 import androidx.annotation.NonNull;
 
@@ -37,8 +38,13 @@ public class CognifyApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
-        Thread.setDefaultUncaughtExceptionHandler((t, e) ->
-                Log.e(TAG, "Uncaught exception in thread " + t.getName(), e));
+        Thread.UncaughtExceptionHandler previousHandler = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+            ExceptionLogger.log(TAG, e);
+            if (previousHandler != null) {
+                previousHandler.uncaughtException(t, e);
+            }
+        });
 
         // (1) Initialize Firebase
         FirebaseApp.initializeApp(this);

--- a/app/src/main/java/com/gigamind/cognify/engine/DictionaryProvider.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/DictionaryProvider.java
@@ -5,6 +5,7 @@ import android.content.res.AssetManager;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import com.gigamind.cognify.util.ExceptionLogger;
 
 import androidx.annotation.NonNull;
 
@@ -52,7 +53,7 @@ public class DictionaryProvider {
                     }
                 }
             } catch (IOException e) {
-                Log.e("DictionaryProvider", "Error preloading dictionary", e);
+                ExceptionLogger.log("DictionaryProvider", e);
             }
             sDictionary = dict;
             sIsLoading = false;
@@ -80,7 +81,11 @@ public class DictionaryProvider {
                 // Already in progress; spin until loaded
                 new Thread(() -> {
                     while (sIsLoading) {
-                        try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+                        try {
+                            Thread.sleep(50);
+                        } catch (InterruptedException e) {
+                            ExceptionLogger.log("DictionaryProvider", e);
+                        }
                     }
                     new Handler(Looper.getMainLooper()).post(() -> callback.onLoaded(sDictionary));
                 }).start();
@@ -103,7 +108,7 @@ public class DictionaryProvider {
                     }
                     reader.close();
                 } catch (IOException e) {
-                    Log.e("DictionaryProvider", "Error loading dictionary", e);
+                    ExceptionLogger.log("DictionaryProvider", e);
                 }
                 // freeze into unmodifiable set
                 sDictionary = Collections.unmodifiableSet(dict);

--- a/app/src/main/java/com/gigamind/cognify/engine/WordGameEngine.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/WordGameEngine.java
@@ -6,6 +6,7 @@ import android.content.res.AssetManager;
 import com.gigamind.cognify.exception.GameException;
 
 import com.gigamind.cognify.util.GameConfig;
+import com.gigamind.cognify.util.ExceptionLogger;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -119,6 +120,7 @@ public class WordGameEngine {
             }
             reader.close();
         } catch (IOException e) {
+            ExceptionLogger.log("WordGameEngine", e);
             throw new GameException(
                     GameException.ErrorCode.DICTIONARY_LOAD_ERROR,
                     "Failed to load dictionary",

--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -29,6 +29,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.android.gms.auth.api.signin.GoogleSignInClient;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.common.api.ApiException;
+import com.gigamind.cognify.util.ExceptionLogger;
 import com.google.android.gms.tasks.Task;
 import com.google.android.material.tabs.TabLayoutMediator;
 import com.google.firebase.auth.AuthCredential;
@@ -260,6 +261,7 @@ public class OnboardingActivity extends AppCompatActivity {
                     firebaseAuthWithGoogle(account.getIdToken(), account);
                 }
             } catch (ApiException e) {
+                ExceptionLogger.log("OnboardingActivity", e);
                 Toast.makeText(this,
                         "Google sign-in failed: " + e.getMessage(),
                         Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/gigamind/cognify/util/ExceptionLogger.java
+++ b/app/src/main/java/com/gigamind/cognify/util/ExceptionLogger.java
@@ -1,0 +1,23 @@
+package com.gigamind.cognify.util;
+
+import android.util.Log;
+
+/**
+ * Utility class for centralized exception logging throughout the app.
+ */
+public final class ExceptionLogger {
+    private static final String DEFAULT_TAG = "ExceptionLogger";
+
+    private ExceptionLogger() {
+        // no instances
+    }
+
+    public static void log(String tag, Throwable t) {
+        if (t == null) return;
+        Log.e(tag != null ? tag : DEFAULT_TAG, t.getMessage(), t);
+    }
+
+    public static void log(Throwable t) {
+        log(DEFAULT_TAG, t);
+    }
+}


### PR DESCRIPTION
## Summary
- create `ExceptionLogger` utility for centralized exception handling
- log dictionary loading exceptions
- log WordGameEngine dictionary errors
- log onboarding sign-in failures
- use `ExceptionLogger` for uncaught exceptions in `CognifyApplication`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842181b3c088332bca538482b07423c