### PR TITLE
Refactor dictionary and permission handling

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/engine/DictionaryProvider.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/DictionaryProvider.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 import com.gigamind.cognify.util.ExceptionLogger;
 
 import androidx.annotation.NonNull;
@@ -12,10 +11,13 @@ import androidx.annotation.NonNull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /**
@@ -31,34 +33,18 @@ public class DictionaryProvider {
         void onLoaded(@NonNull Set<String> dictionary);
     }
 
+    private static final Object LOCK = new Object();
     private static volatile Set<String> sDictionary = null;
     private static volatile boolean sIsLoading = false;
+    private static final List<Callback> pendingCallbacks = new ArrayList<>();
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     /**
      * Call this as early as possible (e.g. Application.onCreate() or MainActivity.onCreate())
      * so that by the time WordDashActivity wants it, it's already ready.
      */
     public static void preloadDictionary(Context context) {
-        if (sDictionary != null || sIsLoading) return;
-        sIsLoading = true;
-
-        new Thread(() -> {
-            Set<String> dict = new HashSet<>();
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(context.getAssets().open("words.txt")))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    if (line.length() >= 3) {
-                        dict.add(line.toUpperCase(Locale.US));
-                    }
-                }
-            } catch (IOException e) {
-                ExceptionLogger.log("DictionaryProvider", e);
-            }
-            sDictionary = dict;
-            sIsLoading = false;
-            // If you need a callback on main thread, you could post to a Handler here.
-        }).start();
+        getDictionaryAsync(context, dictionary -> { /* preload only */ });
     }
 
     /**
@@ -66,54 +52,42 @@ public class DictionaryProvider {
      * Otherwise, kicks off a background load (once) and invokes callback when done.
      */
     public static void getDictionaryAsync(@NonNull Context context, @NonNull Callback callback) {
-        if (sDictionary != null) {
-            // Already loaded → call back immediately on main thread
-            new Handler(Looper.getMainLooper()).post(() -> callback.onLoaded(sDictionary));
-            return;
-        }
-        synchronized (DictionaryProvider.class) {
+        synchronized (LOCK) {
             if (sDictionary != null) {
-                // double‐checked
                 new Handler(Looper.getMainLooper()).post(() -> callback.onLoaded(sDictionary));
                 return;
             }
+
+            pendingCallbacks.add(callback);
             if (sIsLoading) {
-                // Already in progress; spin until loaded
-                new Thread(() -> {
-                    while (sIsLoading) {
-                        try {
-                            Thread.sleep(50);
-                        } catch (InterruptedException e) {
-                            ExceptionLogger.log("DictionaryProvider", e);
-                        }
-                    }
-                    new Handler(Looper.getMainLooper()).post(() -> callback.onLoaded(sDictionary));
-                }).start();
                 return;
             }
-            // Otherwise: start loading
+
             sIsLoading = true;
-            Executors.newSingleThreadExecutor().execute(() -> {
+            executor.execute(() -> {
                 Set<String> dict = new HashSet<>();
-                try {
-                    AssetManager am = context.getAssets();
-                    BufferedReader reader = new BufferedReader(
-                            new InputStreamReader(am.open("words.txt"))
-                    );
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(context.getAssets().open("words.txt")))) {
                     String line;
                     while ((line = reader.readLine()) != null) {
                         if (line.length() >= com.gigamind.cognify.util.GameConfig.MIN_WORD_LENGTH) {
                             dict.add(line.trim().toUpperCase(Locale.US));
                         }
                     }
-                    reader.close();
                 } catch (IOException e) {
                     ExceptionLogger.log("DictionaryProvider", e);
                 }
-                // freeze into unmodifiable set
-                sDictionary = Collections.unmodifiableSet(dict);
-                sIsLoading = false;
-                new Handler(Looper.getMainLooper()).post(() -> callback.onLoaded(sDictionary));
+
+                Set<String> result = Collections.unmodifiableSet(dict);
+                synchronized (LOCK) {
+                    sDictionary = result;
+                    sIsLoading = false;
+                    Handler main = new Handler(Looper.getMainLooper());
+                    for (Callback cb : pendingCallbacks) {
+                        main.post(() -> cb.onLoaded(sDictionary));
+                    }
+                    pendingCallbacks.clear();
+                }
             });
         }
     }

--- a/app/src/main/java/com/gigamind/cognify/util/NotificationPermissionHelper.java
+++ b/app/src/main/java/com/gigamind/cognify/util/NotificationPermissionHelper.java
@@ -1,0 +1,91 @@
+package com.gigamind.cognify.util;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
+
+/**
+ * Helper that encapsulates the logic for requesting the POST_NOTIFICATIONS
+ * permission on Android 13+ devices. This keeps {@link com.gigamind.cognify.ui.OnboardingActivity}
+ * focused on UI logic.
+ */
+public class NotificationPermissionHelper {
+
+    /** Callback for permission result. */
+    public interface PermissionCallback {
+        void onPermissionResult(boolean granted);
+    }
+
+    private final Activity activity;
+    private final SharedPreferences prefs;
+    private final ActivityResultLauncher<String> launcher;
+    private final PermissionCallback callback;
+
+    public NotificationPermissionHelper(@NonNull Activity activity,
+                                        @NonNull SharedPreferences prefs,
+                                        @NonNull PermissionCallback callback) {
+        this.activity = activity;
+        this.prefs = prefs;
+        this.callback = callback;
+        this.launcher = activity.registerForActivityResult(
+                new ActivityResultContracts.RequestPermission(),
+                isGranted -> {
+                    if (isGranted) {
+                        Toast.makeText(activity,
+                                "Notifications enabled. You won't lose your streak!",
+                                Toast.LENGTH_SHORT).show();
+                    } else {
+                        prefs.edit()
+                                .putBoolean(Constants.PREF_ASKED_NOTIFICATIONS, true)
+                                .apply();
+                        Toast.makeText(activity,
+                                "Notifications disabled. You may lose your streak if you don't play.",
+                                Toast.LENGTH_SHORT).show();
+                    }
+                    callback.onPermissionResult(isGranted);
+                }
+        );
+    }
+
+    /**
+     * Checks whether the permission should be requested and, if so,
+     * presents a rationale dialog before launching the system prompt.
+     */
+    public void requestIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return; // Permission not required on older versions
+        }
+        boolean alreadyAsked = prefs.getBoolean(Constants.PREF_ASKED_NOTIFICATIONS, false);
+        if (alreadyAsked) {
+            return;
+        }
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS)
+                == PackageManager.PERMISSION_GRANTED) {
+            return; // Already granted
+        }
+        new AlertDialog.Builder(activity)
+                .setTitle("Keep Your Streak Alive!")
+                .setMessage("We'd like to send you a daily reminder so you won't lose your hard-earned streak. " +
+                        "Allow notifications to receive gentle nudges if you haven't played today.")
+                .setPositiveButton("Enable", (dialog, which) ->
+                        launcher.launch(Manifest.permission.POST_NOTIFICATIONS))
+                .setNegativeButton("No thanks", (dialog, which) -> {
+                    prefs.edit()
+                            .putBoolean(Constants.PREF_ASKED_NOTIFICATIONS, true)
+                            .apply();
+                    dialog.dismiss();
+                    callback.onPermissionResult(false);
+                })
+                .setCancelable(false)
+                .show();
+    }
+}


### PR DESCRIPTION
## Summary
- use observer pattern in `DictionaryProvider` to avoid busy waiting
- encapsulate notification permission logic in `NotificationPermissionHelper`
- simplify `OnboardingActivity` using the new helper

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68421a61396883329162440b9262c7bb