### PR TITLE
Refactor Firebase interactions to central service

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
+++ b/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
@@ -14,7 +14,7 @@ import com.gigamind.cognify.work.StreakNotificationScheduler;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.auth.FirebaseAuth;
+import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.gigamind.cognify.engine.DictionaryProvider;
 import android.content.SharedPreferences;
@@ -58,7 +58,7 @@ public class CognifyApplication extends Application {
         checkNotificationPermission();
 
         // (2) If user is already signed in, attach a real-time listener
-        if (FirebaseAuth.getInstance().getCurrentUser() != null) {
+        if (FirebaseService.getInstance().isUserSignedIn()) {
             listenerRegistration = userRepo.attachUserDocumentListener(new UserRepository.OnUserDataChanged() {
                 @Override
                 public void onDataChanged() {
@@ -69,7 +69,7 @@ public class CognifyApplication extends Application {
                     SharedPreferences prefs = getSharedPreferences(Constants.PREF_NOTIFICATION, MODE_PRIVATE);
                     if (prefs.getBoolean(Constants.PREF_NOTIFICATION_ENABLED, true)) {
                         StreakNotificationScheduler.scheduleFromSharedPrefs(
-                                FirebaseAuth.getInstance().getCurrentUser().getUid(),
+                                FirebaseService.getInstance().getCurrentUserId(),
                                 getApplicationContext()
                         );
                     }

--- a/app/src/main/java/com/gigamind/cognify/analytics/GameAnalytics.java
+++ b/app/src/main/java/com/gigamind/cognify/analytics/GameAnalytics.java
@@ -5,7 +5,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
-import com.google.firebase.auth.FirebaseAuth;
+import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.FirebaseFirestore;
 
@@ -31,10 +31,10 @@ public class GameAnalytics {
 
     private GameAnalytics(Context context) {
         firebaseAnalytics = FirebaseAnalytics.getInstance(context);
-        firestore = FirebaseFirestore.getInstance();
+        firestore = FirebaseService.getInstance().getFirestore();
         prefs = context.getSharedPreferences("GameAnalytics", Context.MODE_PRIVATE);
         
-        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        FirebaseUser user = FirebaseService.getInstance().getCurrentUser();
         userId = user != null ? user.getUid() : "guest_" + prefs.getString("guest_id", "unknown");
         
         wordLengthDistribution = new HashMap<>();

--- a/app/src/main/java/com/gigamind/cognify/data/firebase/FirebaseService.java
+++ b/app/src/main/java/com/gigamind/cognify/data/firebase/FirebaseService.java
@@ -43,6 +43,11 @@ public class FirebaseService {
         return auth.getCurrentUser();
     }
 
+    public String getCurrentUserId() {
+        FirebaseUser user = getCurrentUser();
+        return user != null ? user.getUid() : null;
+    }
+
     public boolean isUserSignedIn() {
         return getCurrentUser() != null;
     }

--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -28,11 +28,10 @@ import com.gigamind.cognify.util.ExceptionLogger;
 import com.google.android.gms.tasks.Task;
 import com.google.android.material.tabs.TabLayoutMediator;
 import com.google.firebase.auth.AuthCredential;
-import com.google.firebase.auth.FirebaseAuth;
+import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.GoogleAuthProvider;
 import com.google.firebase.firestore.DocumentReference;
-import com.google.firebase.firestore.FirebaseFirestore;
 import com.gigamind.cognify.util.Constants;
 
 import java.util.ArrayList;
@@ -50,8 +49,7 @@ public class OnboardingActivity extends AppCompatActivity {
 
     private ActivityOnboardingBinding binding;
     private GoogleSignInClient googleSignInClient;
-    private FirebaseAuth firebaseAuth;
-    private FirebaseFirestore firestore;
+    private FirebaseService firebaseService;
     private SharedPreferences prefs;
     private UserRepository userRepository;
     private NotificationPermissionHelper notificationPermissionHelper;
@@ -64,8 +62,7 @@ public class OnboardingActivity extends AppCompatActivity {
 
         prefs = getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
 
-        firebaseAuth = FirebaseAuth.getInstance();
-        firestore = FirebaseFirestore.getInstance();
+        firebaseService = FirebaseService.getInstance();
         userRepository = new UserRepository(this);
 
         // Configure Google Sign In (web client ID stored in strings.xml)
@@ -199,7 +196,7 @@ public class OnboardingActivity extends AppCompatActivity {
     }
 
     private void setupButtons() {
-        FirebaseUser currentUser = firebaseAuth.getCurrentUser();
+        FirebaseUser currentUser = firebaseService.getCurrentUser();
         if (currentUser != null) {
             // Already signed in
             binding.btnSignIn.setVisibility(View.GONE);
@@ -265,9 +262,9 @@ public class OnboardingActivity extends AppCompatActivity {
 
     private void firebaseAuthWithGoogle(String idToken, GoogleSignInAccount gAccount) {
         AuthCredential credential = GoogleAuthProvider.getCredential(idToken, null);
-        firebaseAuth.signInWithCredential(credential)
+        firebaseService.getAuth().signInWithCredential(credential)
                 .addOnSuccessListener(authResult -> {
-                    FirebaseUser user = firebaseAuth.getCurrentUser();
+                    FirebaseUser user = firebaseService.getCurrentUser();
                     if (user != null) {
                         createOrUpdateUserInFirestore(user, gAccount);
                     } else {
@@ -288,7 +285,7 @@ public class OnboardingActivity extends AppCompatActivity {
         String name = gAccount.getDisplayName();
         String email = gAccount.getEmail();
 
-        DocumentReference userRef = firestore
+        DocumentReference userRef = firebaseService.getFirestore()
                 .collection(FirebaseService.COLLECTION_USERS)
                 .document(uid);
 

--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -38,7 +38,7 @@ import com.gigamind.cognify.util.AnimationUtils;
 import com.gigamind.cognify.work.StreakNotificationScheduler;
 import com.google.android.gms.tasks.Task;
 import com.google.android.material.button.MaterialButton;
-import com.google.firebase.auth.FirebaseAuth;
+import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.google.firebase.auth.FirebaseUser;
 
 import java.text.SimpleDateFormat;
@@ -81,7 +81,7 @@ public class ResultActivity extends AppCompatActivity {
 
         prefs          = getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
         userRepository = new UserRepository(this);
-        firebaseUser   = FirebaseAuth.getInstance().getCurrentUser();
+        firebaseUser   = FirebaseService.getInstance().getCurrentUser();
 
         int score        = getIntent().getIntExtra(INTENT_SCORE, 0);
         String gameType  = getIntent().getStringExtra(INTENT_TYPE);

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -28,7 +28,7 @@ import android.graphics.Color;
 import android.content.res.ColorStateList;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.snackbar.Snackbar;
-import com.google.firebase.auth.FirebaseAuth;
+import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.ListenerRegistration;
 
@@ -79,7 +79,7 @@ public class HomeFragment extends Fragment {
         userRepository = new UserRepository(requireContext());
 
         // Check signed-in user
-        firebaseUser = FirebaseAuth.getInstance().getCurrentUser();
+        firebaseUser = FirebaseService.getInstance().getCurrentUser();
 
         // 1) Populate the streak UI
         loadAndDisplayStreak();

--- a/app/src/main/java/com/gigamind/cognify/ui/leaderboard/LeaderboardAdapter.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/leaderboard/LeaderboardAdapter.java
@@ -10,7 +10,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.gigamind.cognify.R;
 import com.gigamind.cognify.databinding.ItemLeaderboardBinding;
-import com.google.firebase.auth.FirebaseAuth;
+import com.gigamind.cognify.data.firebase.FirebaseService;
 
 public class LeaderboardAdapter extends ListAdapter<LeaderboardItem, LeaderboardAdapter.ViewHolder> {
 
@@ -64,8 +64,8 @@ public class LeaderboardAdapter extends ListAdapter<LeaderboardItem, Leaderboard
             binding.pointsText.setText(String.valueOf(item.getTotalXP()));
 
             // 6) Highlight current user row
-            String currentUid = FirebaseAuth.getInstance().getCurrentUser() != null
-                    ? FirebaseAuth.getInstance().getCurrentUser().getUid()
+            String currentUid = FirebaseService.getInstance().getCurrentUser() != null
+                    ? FirebaseService.getInstance().getCurrentUserId()
                     : "";
             boolean isCurrent = currentUid.equals(item.getUserId());
             binding.getRoot().setSelected(isCurrent);

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -19,7 +19,7 @@ import com.gigamind.cognify.databinding.FragmentSettingsBinding;
 import com.gigamind.cognify.ui.OnboardingActivity;
 import com.gigamind.cognify.util.Constants;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.firebase.auth.FirebaseAuth;
+import com.gigamind.cognify.data.firebase.FirebaseService;
 
 public class SettingsFragment extends Fragment {
     private FragmentSettingsBinding binding;
@@ -92,8 +92,8 @@ public class SettingsFragment extends Fragment {
         });
 
         // Show sign in or sign out button based on auth state
-        FirebaseAuth auth = FirebaseAuth.getInstance();
-        if (auth.getCurrentUser() != null) {
+        FirebaseService service = FirebaseService.getInstance();
+        if (service.isUserSignedIn()) {
             binding.btnSignIn.setText(R.string.sign_out);
             binding.btnSignIn.setOnClickListener(v -> {
                 new MaterialAlertDialogBuilder(requireContext())
@@ -115,7 +115,7 @@ public class SettingsFragment extends Fragment {
                                     .remove(UserRepository.KEY_PERSONAL_BEST_XP)
                                     .apply();
 
-                            FirebaseAuth.getInstance().signOut();
+                            FirebaseService.getInstance().signOut();
                             Intent i = new Intent(requireActivity(), OnboardingActivity.class);
                             i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                             startActivity(i);

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -24,7 +24,7 @@ import com.gigamind.cognify.ui.WordDashActivity;
 import com.gigamind.cognify.util.Constants;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.button.MaterialButton;
-import com.google.firebase.auth.FirebaseAuth;
+import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.ListenerRegistration;
 
@@ -71,7 +71,7 @@ public class WordDashFragment extends Fragment {
         userRepository = new UserRepository(requireContext());
 
         // Check signed-in user
-        firebaseUser = FirebaseAuth.getInstance().getCurrentUser();
+        firebaseUser = FirebaseService.getInstance().getCurrentUser();
 
         // 1) Populate the streak UI
         loadAndDisplayStreak();

--- a/app/src/main/java/com/gigamind/cognify/work/StreakNotificationWorker.java
+++ b/app/src/main/java/com/gigamind/cognify/work/StreakNotificationWorker.java
@@ -16,7 +16,7 @@ import androidx.work.WorkerParameters;
 import com.gigamind.cognify.R;
 import com.gigamind.cognify.data.repository.UserRepository;
 import com.gigamind.cognify.ui.MainActivity;
-import com.google.firebase.auth.FirebaseAuth;
+import com.gigamind.cognify.data.firebase.FirebaseService;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -74,9 +74,7 @@ public class StreakNotificationWorker extends Worker {
         if (currentStreak > 0) {
             StreakNotificationScheduler.scheduleFromSharedPrefs(
                     /*firebaseUid=*/ (repo.getLastPlayedTimestamp() > 0 ?
-                            (FirebaseAuth.getInstance().getCurrentUser() != null
-                                    ? FirebaseAuth.getInstance().getCurrentUser().getUid()
-                                    : null)
+                            FirebaseService.getInstance().getCurrentUserId()
                             : null),
                     ctx
             );


### PR DESCRIPTION
## Summary
- centralize Firebase usage via `FirebaseService`
- update activities and fragments to use the singleton service
- expose helper for current user id

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68421f99227c833286f176603d18d977