### PR TITLE
Fix QuickMath hang when subtraction result is negative

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/engine/MathGameEngine.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/MathGameEngine.java
@@ -22,6 +22,11 @@ public class MathGameEngine {
         int op = random.nextInt(4); // 0:+ 1:- 2:* 3:/
         switch (op) {
             case 1:
+                if (a < b) {
+                    int temp = a;
+                    a = b;
+                    b = temp;
+                }
                 currentAnswer = a - b;
                 currentQuestion = a + " - " + b + " = ?";
                 break;


### PR DESCRIPTION
## Summary
- ensure subtraction questions do not produce a negative answer

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685086b19ee48332b49615a5b7bfe6db