### PR TITLE
Add Word Dash tutorial hints

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -23,6 +23,7 @@ import com.gigamind.cognify.util.Constants;
 import com.gigamind.cognify.util.GameConfig;
 import com.gigamind.cognify.util.GameType;
 import com.gigamind.cognify.util.GameTimer;
+import com.gigamind.cognify.util.TutorialHelper;
 import com.google.android.flexbox.FlexDirection;
 import com.google.android.flexbox.FlexWrap;
 import com.google.android.flexbox.FlexboxLayoutManager;
@@ -50,6 +51,8 @@ public class WordDashActivity extends AppCompatActivity {
 
     private GameAnalytics analytics;
     private long wordStartTime;
+    private TutorialHelper tutorialHelper;
+    private boolean tutorialActive = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -59,6 +62,8 @@ public class WordDashActivity extends AppCompatActivity {
         analytics = GameAnalytics.getInstance(this);
         analytics.logScreenView(Constants.ANALYTICS_SCREEN_WORD_DASH);
         analytics.logGameStart(GameType.WORD);
+
+        tutorialHelper = new TutorialHelper(this);
         
         // 1) Bind all views and set up UI scaffolding that does NOT use gameEngine yet
         initializeViews();
@@ -82,6 +87,10 @@ public class WordDashActivity extends AppCompatActivity {
 
                         enableGameInteractions();
                         isDictionaryLoaded = true;
+                        if (!tutorialHelper.isTutorialCompleted()) {
+                            tutorialActive = true;
+                            Toast.makeText(this, R.string.tutorial_start_hint, Toast.LENGTH_LONG).show();
+                        }
                         startGame();       // Begin the game timer
                     } else {
                         // Handle dictionary load error
@@ -227,6 +236,11 @@ public class WordDashActivity extends AppCompatActivity {
 
             foundWordsList.add(word);
             foundWordsAdapter.submitList(new ArrayList<>(foundWordsList));
+            if (tutorialActive) {
+                Toast.makeText(this, R.string.tutorial_complete, Toast.LENGTH_SHORT).show();
+                tutorialHelper.markTutorialCompleted();
+                tutorialActive = false;
+            }
         } else {
             showError(getString(R.string.invalid_word));
             analytics.logInvalidWord(word);

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -22,6 +23,7 @@ import com.gigamind.cognify.databinding.FragmentWordDashBinding;
 import com.gigamind.cognify.ui.QuickMathActivity;
 import com.gigamind.cognify.ui.WordDashActivity;
 import com.gigamind.cognify.util.Constants;
+import com.gigamind.cognify.util.TutorialHelper;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.button.MaterialButton;
 import com.gigamind.cognify.data.firebase.FirebaseService;
@@ -45,6 +47,7 @@ public class WordDashFragment extends Fragment {
     private FirebaseUser firebaseUser;
     private ListenerRegistration homeListener;
     private ImageView userProfileButton;
+    private TutorialHelper tutorialHelper;
 
     @Nullable
     @Override
@@ -66,9 +69,10 @@ public class WordDashFragment extends Fragment {
         // Initialize views
         initializeViews();
 
-        // Initialize SharedPreferences and UserRepository
+        // Initialize SharedPreferences, repositories and helpers
         prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
         userRepository = new UserRepository(requireContext());
+        tutorialHelper = new TutorialHelper(requireContext());
 
         // Check signed-in user
         firebaseUser = FirebaseService.getInstance().getCurrentUser();
@@ -116,6 +120,9 @@ public class WordDashFragment extends Fragment {
     private void setupClickListeners() {
         View.OnClickListener animatedClickListener = v -> {
             v.startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.button_bounce));
+            if (!tutorialHelper.isTutorialCompleted()) {
+                Toast.makeText(requireContext(), R.string.play_tip, Toast.LENGTH_SHORT).show();
+            }
             handleGameLaunch(v);
         };
         wordGamePlayButton.setOnClickListener(animatedClickListener);

--- a/app/src/main/java/com/gigamind/cognify/util/Constants.java
+++ b/app/src/main/java/com/gigamind/cognify/util/Constants.java
@@ -21,6 +21,7 @@ public class Constants {
     public static final String PREF_IS_GUEST = "is_guest_mode";
     public static final String PREF_NOTIFICATION = "notification_preferences";
     public static final String PREF_NOTIFICATION_ENABLED = "notifications_enabled";
+    public static final String PREF_TUTORIAL_COMPLETED = "tutorial_completed";
 
     // Intent extras and other keys
     public static final String INTENT_GAME_TYPE = "GAME_TYPE";

--- a/app/src/main/java/com/gigamind/cognify/util/TutorialHelper.java
+++ b/app/src/main/java/com/gigamind/cognify/util/TutorialHelper.java
@@ -1,0 +1,29 @@
+package com.gigamind.cognify.util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * Helper for managing the first-time Word Dash tutorial state.
+ */
+public class TutorialHelper {
+    private final SharedPreferences prefs;
+
+    public TutorialHelper(Context context) {
+        this.prefs = context.getSharedPreferences(Constants.PREF_APP, Context.MODE_PRIVATE);
+    }
+
+    /**
+     * Returns true if the user already completed the tutorial.
+     */
+    public boolean isTutorialCompleted() {
+        return prefs.getBoolean(Constants.PREF_TUTORIAL_COMPLETED, false);
+    }
+
+    /**
+     * Marks the tutorial as completed.
+     */
+    public void markTutorialCompleted() {
+        prefs.edit().putBoolean(Constants.PREF_TUTORIAL_COMPLETED, true).apply();
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,4 +151,7 @@
         Join me on Cognify! Download on Play Store: https://example.com/app
     </string>
     <string name="invite_chooser_title">Invite Friends</string>
+    <string name="play_tip">You\u2019ll see a quick tutorial first.</string>
+    <string name="tutorial_start_hint">Tap letters to form a word, then hit Submit.</string>
+    <string name="tutorial_complete">Great! Tutorial complete.</string>
 </resources>

--- a/app/src/test/java/com/gigamind/cognify/util/ConstantsTest.java
+++ b/app/src/test/java/com/gigamind/cognify/util/ConstantsTest.java
@@ -16,5 +16,6 @@ public class ConstantsTest {
     void testPreferences() {
         assertNotNull(Constants.PREFS_NAME);
         assertNotNull(Constants.PREF_APP);
+        assertEquals("tutorial_completed", Constants.PREF_TUTORIAL_COMPLETED);
     }
 }


### PR DESCRIPTION
## Summary
- add tutorial completion flag in `Constants`
- show tooltip on Play button and hint when dictionary loads
- mark tutorial complete after submitting first word
- add `TutorialHelper` utility
- update unit tests and strings

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68508737d2ac8332bf346b473958687d