### PR TITLE
Add rotating quest system

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
+++ b/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 import com.gigamind.cognify.data.repository.UserRepository;
 import com.gigamind.cognify.util.Constants;
 import com.gigamind.cognify.work.StreakNotificationScheduler;
+import com.gigamind.cognify.work.QuestNotificationScheduler;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
@@ -72,6 +73,7 @@ public class CognifyApplication extends Application {
                                 FirebaseService.getInstance().getCurrentUserId(),
                                 getApplicationContext()
                         );
+                        QuestNotificationScheduler.scheduleDaily(getApplicationContext());
                     }
 
                     // We only need to schedule once on cold start; after that the Worker will
@@ -86,6 +88,7 @@ public class CognifyApplication extends Application {
             // (3) Not signed in → schedule the Worker immediately from whatever prefs we already have
             StreakNotificationScheduler.scheduleFromSharedPrefs(/*firebaseUid=*/ null,
                     getApplicationContext());
+            QuestNotificationScheduler.scheduleDaily(getApplicationContext());
         }
     }
 

--- a/app/src/main/java/com/gigamind/cognify/model/Quest.java
+++ b/app/src/main/java/com/gigamind/cognify/model/Quest.java
@@ -1,0 +1,12 @@
+package com.gigamind.cognify.model;
+
+/** Simple data class representing a quest description and reward. */
+public class Quest {
+    public final String description;
+    public final String reward;
+
+    public Quest(String description, String reward) {
+        this.description = description;
+        this.reward = reward;
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -24,6 +24,8 @@ import com.gigamind.cognify.databinding.FragmentHomeBinding;
 import com.gigamind.cognify.ui.QuickMathActivity;
 import com.gigamind.cognify.ui.WordDashActivity;
 import com.gigamind.cognify.util.Constants;
+import com.gigamind.cognify.model.Quest;
+import com.gigamind.cognify.util.QuestManager;
 import android.graphics.Color;
 import android.content.res.ColorStateList;
 import com.google.android.material.button.MaterialButton;
@@ -49,6 +51,9 @@ public class HomeFragment extends Fragment {
     private CardView playQuickMathButton;
     private RelativeLayout cardView;
     private TextView streakCount;
+    private TextView questTitle;
+    private TextView questDescription;
+    private TextView questReward;
     private SharedPreferences prefs;
     private UserRepository userRepository;
     private FirebaseUser firebaseUser;
@@ -87,6 +92,9 @@ public class HomeFragment extends Fragment {
         // 2) Set up daily challenge text
         setupDailyChallenge();
 
+        // 2b) Set up quest card
+        setupQuestCard();
+
         // 3) Configure game cards
         setupGameCards();
 
@@ -103,6 +111,9 @@ public class HomeFragment extends Fragment {
         playQuickMathButton = binding.mathGameCard.getRoot();
         cardView = binding.welcomeCardView;
         streakCount = binding.streakCount;
+        questTitle = binding.questTitle;
+        questDescription = binding.questDescription;
+        questReward = binding.questReward;
         wordGamePlayButton = binding.wordGameCard.playButton;
         quickMathPlayButton = binding.mathGameCard.playButton;
     }
@@ -151,6 +162,14 @@ public class HomeFragment extends Fragment {
             dailyChallengeTitle.setText(getString(R.string.completed_today));
             dailyChallengeTitle.setEnabled(false);
         }
+    }
+
+    /** Displays the rotating daily quest on the quest card. */
+    private void setupQuestCard() {
+        Quest quest = QuestManager.getDailyQuest();
+        questTitle.setText(getString(R.string.daily_quest));
+        questDescription.setText(quest.description);
+        questReward.setText(getString(R.string.quest_reward, quest.reward));
     }
 
     /** Sets titles, backgrounds and button colors for the game cards. */

--- a/app/src/main/java/com/gigamind/cognify/util/QuestManager.java
+++ b/app/src/main/java/com/gigamind/cognify/util/QuestManager.java
@@ -1,0 +1,32 @@
+package com.gigamind.cognify.util;
+
+import com.gigamind.cognify.model.Quest;
+import java.util.Calendar;
+
+/** Provides rotating daily and weekly quests. */
+public final class QuestManager {
+    private static final Quest[] DAILY_QUESTS = new Quest[] {
+            new Quest("Find 10 four-letter words", "50 XP"),
+            new Quest("Score 200 points in Math", "50 XP"),
+            new Quest("Play Word Dash for 2 minutes", "Badge: Speedster")
+    };
+
+    private static final Quest[] WEEKLY_QUESTS = new Quest[] {
+            new Quest("Complete 5 Daily Challenges", "Double XP Coupon"),
+            new Quest("Reach 1000 XP this week", "Badge: Weekly Warrior")
+    };
+
+    private QuestManager() { /* no instances */ }
+
+    /** Returns today's rotating daily quest. */
+    public static Quest getDailyQuest() {
+        int index = Calendar.getInstance().get(Calendar.DAY_OF_YEAR) % DAILY_QUESTS.length;
+        return DAILY_QUESTS[index];
+    }
+
+    /** Returns this week's rotating quest. */
+    public static Quest getWeeklyQuest() {
+        int index = Calendar.getInstance().get(Calendar.WEEK_OF_YEAR) % WEEKLY_QUESTS.length;
+        return WEEKLY_QUESTS[index];
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/work/QuestNotificationScheduler.java
+++ b/app/src/main/java/com/gigamind/cognify/work/QuestNotificationScheduler.java
@@ -1,0 +1,39 @@
+package com.gigamind.cognify.work;
+
+import android.content.Context;
+
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+import androidx.work.WorkRequest;
+
+import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
+
+/** Schedules daily quest reminder notifications. */
+public class QuestNotificationScheduler {
+    private static final String UNIQUE_WORK_NAME = "quest_notification_work";
+
+    public static void scheduleDaily(Context context) {
+        long now = System.currentTimeMillis();
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.HOUR_OF_DAY, 18); // 6 PM reminder
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        long runAt = cal.getTimeInMillis();
+        if (runAt <= now) runAt += TimeUnit.DAYS.toMillis(1);
+        long delay = runAt - now;
+
+        WorkRequest work = new OneTimeWorkRequest.Builder(QuestNotificationWorker.class)
+                .setInitialDelay(delay, TimeUnit.MILLISECONDS)
+                .addTag(UNIQUE_WORK_NAME)
+                .build();
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+                UNIQUE_WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                (OneTimeWorkRequest) work
+        );
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/work/QuestNotificationWorker.java
+++ b/app/src/main/java/com/gigamind/cognify/work/QuestNotificationWorker.java
@@ -1,0 +1,80 @@
+package com.gigamind.cognify.work;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import com.gigamind.cognify.R;
+import com.gigamind.cognify.ui.MainActivity;
+
+/** Worker that posts the daily quest reminder notification. */
+public class QuestNotificationWorker extends Worker {
+    private static final String CHANNEL_ID = "quest_reminder_channel";
+    private static final int NOTIF_ID = 4001;
+
+    public QuestNotificationWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        sendQuestNotification(getApplicationContext());
+        QuestNotificationScheduler.scheduleDaily(getApplicationContext());
+        return Result.success();
+    }
+
+    private void sendQuestNotification(Context context) {
+        createNotificationChannelIfNeeded(context);
+
+        Intent toMain = new Intent(context, MainActivity.class);
+        toMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+
+        PendingIntent pi = PendingIntent.getActivity(
+                context,
+                0,
+                toMain,
+                PendingIntent.FLAG_UPDATE_CURRENT
+                        | (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                        ? PendingIntent.FLAG_IMMUTABLE
+                        : 0)
+        );
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_streak)
+                .setContentTitle(context.getString(R.string.notif_quest_title))
+                .setContentText(context.getString(R.string.notif_quest_text))
+                .setAutoCancel(true)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setContentIntent(pi);
+
+        NotificationManager nm =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm != null) {
+            nm.notify(NOTIF_ID, builder.build());
+        }
+    }
+
+    private void createNotificationChannelIfNeeded(Context ctx) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = ctx.getString(R.string.quest_channel_name);
+            String description = ctx.getString(R.string.quest_channel_desc);
+            int importance = NotificationManager.IMPORTANCE_HIGH;
+
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
+            channel.setDescription(description);
+
+            NotificationManager nm =
+                    (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (nm != null) nm.createNotificationChannel(channel);
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -147,6 +147,49 @@
             </RelativeLayout>
         </androidx.cardview.widget.CardView>
 
+        <androidx.cardview.widget.CardView
+            android:id="@+id/questCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="8dp"
+            android:backgroundTint="@android:color/transparent"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="6dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:id="@+id/questTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/daily_quest"
+                    android:textColor="@android:color/white"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/questDescription"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:textColor="@android:color/white"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:id="@+id/questReward"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:textColor="#FFFF00"
+                    android:textSize="14sp" />
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
         <!-- Game Modes Section -->
         <TextView
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,4 +151,10 @@
         Join me on Cognify! Download on Play Store: https://example.com/app
     </string>
     <string name="invite_chooser_title">Invite Friends</string>
+    <string name="daily_quest">Daily Quest</string>
+    <string name="quest_reward">Reward: %1$s</string>
+    <string name="notif_quest_title">Daily Quest Reminder</string>
+    <string name="notif_quest_text">Complete todays quest to earn extra XP!</string>
+    <string name="quest_channel_name">Quest Reminder</string>
+    <string name="quest_channel_desc">Notifies about daily quests</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `QuestManager` and `Quest` model for rotating quests
- display quest card in `HomeFragment`
- send quest reminder via new WorkManager workers
- schedule quest notifications from `CognifyApplication`
- update strings and layout for quest UI

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850875bcc7c8332bfa756f0376b92ba