### PR TITLE
Implement trophy room and tier badges

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,10 @@
             android:exported="false"
             android:screenOrientation="portrait" />
 
+        <activity
+            android:name="com.gigamind.cognify.ui.trophy.TrophyRoomActivity"
+            android:exported="false" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -139,6 +139,16 @@ public class ResultActivity extends AppCompatActivity {
 
         editor.apply();
 
+        int oldBadge = com.gigamind.cognify.util.BadgeUtils.badgeIndexForXp(oldTotalXp);
+        int newBadge = com.gigamind.cognify.util.BadgeUtils.badgeIndexForXp(newTotalXp);
+        if (newBadge > oldBadge) {
+            android.widget.Toast.makeText(
+                    this,
+                    getString(R.string.trophy_room) + ": " + com.gigamind.cognify.util.BadgeUtils.NAMES[newBadge],
+                    android.widget.Toast.LENGTH_LONG
+            ).show();
+        }
+
         // (8) Kick off Firestore merge in background
         Task<Void> updateTask = userRepository.updateGameResults(
                 gameType, score, xpEarned, newPbValue

--- a/app/src/main/java/com/gigamind/cognify/ui/leaderboard/LeaderboardAdapter.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/leaderboard/LeaderboardAdapter.java
@@ -60,6 +60,13 @@ public class LeaderboardAdapter extends ListAdapter<LeaderboardItem, Leaderboard
             // 3) Display Name
             binding.nameText.setText(item.getName());
 
+            // Badge icon and description
+            int badgeIdx = com.gigamind.cognify.util.BadgeUtils.badgeIndexForXp(item.getTotalXP());
+            binding.badgeIcon.setImageResource(
+                    com.gigamind.cognify.util.BadgeUtils.badgeIconResId(badgeIdx));
+            binding.badgeIcon.setContentDescription(
+                    com.gigamind.cognify.util.BadgeUtils.NAMES[badgeIdx]);
+
             // 5) Points (Total XP)
             binding.pointsText.setText(String.valueOf(item.getTotalXP()));
 

--- a/app/src/main/java/com/gigamind/cognify/ui/leaderboard/LeaderboardItem.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/leaderboard/LeaderboardItem.java
@@ -66,19 +66,10 @@ public class LeaderboardItem {
     }
 
     /**
-     * Based on totalXP, return a badge type string:
-     *  - "bronze" if XP < 1000,
-     *  - "silver" if 1000 ≤ XP < 2000,
-     *  - "gold" if XP ≥ 2000.
-     * You can adjust these thresholds as desired.
+     * Returns the badge tier name for this item's total XP.
+     * The mapping of XP ranges to badge names lives in {@link com.gigamind.cognify.util.BadgeUtils}.
      */
     public String getBadgeType() {
-        if (totalXP >= 2000) {
-            return "gold";
-        } else if (totalXP >= 1000) {
-            return "silver";
-        } else {
-            return "bronze";
-        }
+        return com.gigamind.cognify.util.BadgeUtils.badgeNameForXp(totalXP);
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -40,6 +40,7 @@ public class ProfileFragment extends Fragment {
     private TextView streakValueText;
     private TextView xpValueText;
     private Button inviteFriendsButton;
+    private Button trophyRoomButton;
 
     private UserRepository userRepository;
     private FirebaseUser firebaseUser;
@@ -68,6 +69,7 @@ public class ProfileFragment extends Fragment {
         streakValueText         = view.findViewById(R.id.streakValue);
         xpValueText             = view.findViewById(R.id.xpValue);
         inviteFriendsButton     = view.findViewById(R.id.inviteFriendsButton);
+        trophyRoomButton        = view.findViewById(R.id.trophyRoomButton);
 
         // 2) Initialize FirebaseUser & UserRepository
         firebaseUser   = FirebaseService.getInstance().getCurrentUser();
@@ -158,6 +160,11 @@ public class ProfileFragment extends Fragment {
                     getString(R.string.invite_message)
             );
             startActivity(Intent.createChooser(shareIntent, getString(R.string.invite_chooser_title)));
+        });
+
+        trophyRoomButton.setOnClickListener(v -> {
+            Intent intent = new Intent(requireContext(), com.gigamind.cognify.ui.trophy.TrophyRoomActivity.class);
+            startActivity(intent);
         });
     }
 

--- a/app/src/main/java/com/gigamind/cognify/ui/trophy/TrophyRoomActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/trophy/TrophyRoomActivity.java
@@ -1,0 +1,38 @@
+package com.gigamind.cognify.ui.trophy;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.gigamind.cognify.R;
+import com.gigamind.cognify.data.repository.UserRepository;
+import com.gigamind.cognify.util.BadgeUtils;
+
+/** Simple activity showing unlocked badge tiers. */
+public class TrophyRoomActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_trophy_room);
+
+        LinearLayout list = findViewById(R.id.trophyList);
+        int totalXp = new UserRepository(this).getTotalXP();
+        int unlockedIdx = BadgeUtils.badgeIndexForXp(totalXp);
+
+        LayoutInflater inflater = LayoutInflater.from(this);
+        for (int i = 0; i < BadgeUtils.NAMES.length; i++) {
+            LinearLayout item = (LinearLayout) inflater.inflate(R.layout.item_trophy, list, false);
+            ImageView icon = item.findViewById(R.id.trophyIcon);
+            TextView name = item.findViewById(R.id.trophyName);
+            icon.setImageResource(BadgeUtils.badgeIconResId(i));
+            name.setText(BadgeUtils.NAMES[i]);
+            item.setAlpha(i <= unlockedIdx ? 1f : 0.3f);
+            list.addView(item);
+        }
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/util/BadgeUtils.java
+++ b/app/src/main/java/com/gigamind/cognify/util/BadgeUtils.java
@@ -1,0 +1,41 @@
+package com.gigamind.cognify.util;
+
+import androidx.annotation.NonNull;
+
+/** Utility class for mapping XP to badge tiers. */
+public final class BadgeUtils {
+    private BadgeUtils() {}
+
+    public static final int[] THRESHOLDS = {
+            0, 500, 1000, 1500, 2000, 3000, 4000, 5000, 7000, 9000
+    };
+
+    public static final String[] NAMES = {
+            "Rookie", "Apprentice", "Adept", "Expert", "Veteran",
+            "Elite", "Master", "Champion", "Hero", "Legend"
+    };
+
+    /** Returns the badge index (0..9) for the given total XP. */
+    public static int badgeIndexForXp(int xp) {
+        int index = 0;
+        for (int i = 0; i < THRESHOLDS.length; i++) {
+            if (xp >= THRESHOLDS[i]) {
+                index = i;
+            } else {
+                break;
+            }
+        }
+        return index;
+    }
+
+    /** Returns the badge name for the given XP total. */
+    @NonNull
+    public static String badgeNameForXp(int xp) {
+        return NAMES[badgeIndexForXp(xp)];
+    }
+
+    /** Returns the drawable resource for the given badge index. */
+    public static int badgeIconResId(int index) {
+        return com.gigamind.cognify.R.drawable.ic_badge; // placeholder
+    }
+}

--- a/app/src/main/res/layout/activity_trophy_room.xml
+++ b/app/src/main/res/layout/activity_trophy_room.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/trophy_room"
+            android:textColor="@android:color/white"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+
+        <LinearLayout
+            android:id="@+id/trophyList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="16dp" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -335,6 +335,13 @@
                 android:layout_marginTop="8dp"
                 android:text="@string/invite_friends_button" />
 
+            <Button
+                android:id="@+id/trophyRoomButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:text="@string/trophy_room" />
+
         </LinearLayout>
 
 

--- a/app/src/main/res/layout/item_leaderboard.xml
+++ b/app/src/main/res/layout/item_leaderboard.xml
@@ -43,6 +43,15 @@
             android:layout_weight="4"
             />
 
+        <!-- Badge icon -->
+        <ImageView
+            android:id="@+id/badgeIcon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="8dp"
+            android:src="@drawable/ic_badge" />
+
         <!-- 5) Points (Total XP) -->
         <TextView
             android:id="@+id/pointsText"

--- a/app/src/main/res/layout/item_trophy.xml
+++ b/app/src/main/res/layout/item_trophy.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/trophyIcon"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:src="@drawable/ic_badge" />
+
+    <TextView
+        android:id="@+id/trophyName"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="12dp"
+        android:textColor="@android:color/white"
+        android:textSize="18sp" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,4 +151,17 @@
         Join me on Cognify! Download on Play Store: https://example.com/app
     </string>
     <string name="invite_chooser_title">Invite Friends</string>
+
+    <!-- Trophy Room -->
+    <string name="trophy_room">Trophy Room</string>
+    <string name="badge_rookie">Rookie</string>
+    <string name="badge_apprentice">Apprentice</string>
+    <string name="badge_adept">Adept</string>
+    <string name="badge_expert">Expert</string>
+    <string name="badge_veteran">Veteran</string>
+    <string name="badge_elite">Elite</string>
+    <string name="badge_master">Master</string>
+    <string name="badge_champion">Champion</string>
+    <string name="badge_hero">Hero</string>
+    <string name="badge_legend">Legend</string>
 </resources>

--- a/app/src/test/java/com/gigamind/cognify/ui/leaderboard/LeaderboardItemTest.java
+++ b/app/src/test/java/com/gigamind/cognify/ui/leaderboard/LeaderboardItemTest.java
@@ -7,7 +7,18 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class LeaderboardItemTest {
     @ParameterizedTest
-    @CsvSource({"50,bronze", "0,bronze", "-10,bronze", "1000,silver", "1500,silver", "2000,gold", "2500,gold"})
+    @CsvSource({
+            "0,Rookie",
+            "500,Apprentice",
+            "1200,Adept",
+            "1600,Expert",
+            "2500,Veteran",
+            "3500,Elite",
+            "4500,Master",
+            "5200,Champion",
+            "7500,Hero",
+            "9500,Legend"
+    })
     void badgeTypeMatchesXpThreshold(int xp, String expected) {
         LeaderboardItem item = new LeaderboardItem("id", "name", xp, "US");
         assertEquals(expected, item.getBadgeType());


### PR DESCRIPTION
## Summary
- add BadgeUtils for mapping XP to tier names
- show badge icons in leaderboard rows
- toast when a badge tier is unlocked
- add TrophyRoomActivity and layouts
- link trophy room from profile screen
- expand leaderboard badge tests for 10 tiers

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68508789383883328110304669bdacd7