### PR TITLE
Add avatar customization and new profile stats

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -140,8 +140,9 @@ public class ResultActivity extends AppCompatActivity {
         editor.apply();
 
         // (8) Kick off Firestore merge in background
+        boolean isWin = score > 0;
         Task<Void> updateTask = userRepository.updateGameResults(
-                gameType, score, xpEarned, newPbValue
+                gameType, score, xpEarned, isWin, newPbValue
         );
 
         // (9) Schedule next streak notification (uses prefs key we just wrote)

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/AvatarCustomizationFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/AvatarCustomizationFragment.java
@@ -1,0 +1,96 @@
+package com.gigamind.cognify.ui.profile;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ImageView;
+import android.widget.Spinner;
+import android.widget.Button;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.gigamind.cognify.R;
+import com.gigamind.cognify.util.Constants;
+
+/**
+ * Simple UI allowing the user to select avatar frame, hat and color.
+ * Stores the selections in SharedPreferences under PREF_APP.
+ */
+public class AvatarCustomizationFragment extends Fragment {
+    private ImageView avatarPreview;
+    private Spinner frameSpinner;
+    private Spinner hatSpinner;
+    private Spinner colorSpinner;
+    private SharedPreferences prefs;
+
+    private static final String KEY_AVATAR_FRAME = "avatar_frame";
+    private static final String KEY_AVATAR_HAT = "avatar_hat";
+    private static final String KEY_AVATAR_COLOR = "avatar_color";
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_avatar_customization, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        prefs = requireContext().getSharedPreferences(Constants.PREF_APP, Context.MODE_PRIVATE);
+
+        avatarPreview = view.findViewById(R.id.avatarPreview);
+        frameSpinner = view.findViewById(R.id.frameSpinner);
+        hatSpinner = view.findViewById(R.id.hatSpinner);
+        colorSpinner = view.findViewById(R.id.colorSpinner);
+        Button saveButton = view.findViewById(R.id.saveAvatarButton);
+
+        setupSpinners();
+        loadSelections();
+
+        saveButton.setOnClickListener(v -> {
+            prefs.edit()
+                    .putString(KEY_AVATAR_FRAME, frameSpinner.getSelectedItem().toString())
+                    .putString(KEY_AVATAR_HAT, hatSpinner.getSelectedItem().toString())
+                    .putString(KEY_AVATAR_COLOR, colorSpinner.getSelectedItem().toString())
+                    .apply();
+            requireActivity().onBackPressed();
+        });
+    }
+
+    private void setupSpinners() {
+        ArrayAdapter<String> frameAdapter = new ArrayAdapter<>(requireContext(),
+                android.R.layout.simple_spinner_item,
+                new String[]{"Circle", "Square"});
+        frameAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        frameSpinner.setAdapter(frameAdapter);
+
+        ArrayAdapter<String> hatAdapter = new ArrayAdapter<>(requireContext(),
+                android.R.layout.simple_spinner_item,
+                new String[]{"None", "Crown", "Cap"});
+        hatAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        hatSpinner.setAdapter(hatAdapter);
+
+        ArrayAdapter<String> colorAdapter = new ArrayAdapter<>(requireContext(),
+                android.R.layout.simple_spinner_item,
+                new String[]{"Blue", "Green", "Red"});
+        colorAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        colorSpinner.setAdapter(colorAdapter);
+    }
+
+    private void loadSelections() {
+        String frame = prefs.getString(KEY_AVATAR_FRAME, "Circle");
+        String hat = prefs.getString(KEY_AVATAR_HAT, "None");
+        String color = prefs.getString(KEY_AVATAR_COLOR, "Blue");
+
+        frameSpinner.setSelection(frame.equals("Square") ? 1 : 0);
+        hatSpinner.setSelection(hat.equals("Crown") ? 1 : hat.equals("Cap") ? 2 : 0);
+        colorSpinner.setSelection(color.equals("Green") ? 1 : color.equals("Red") ? 2 : 0);
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -2,6 +2,8 @@ package com.gigamind.cognify.ui.profile;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,10 +16,12 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import com.gigamind.cognify.ui.profile.AvatarCustomizationFragment;
 
 import com.gigamind.cognify.R;
 import com.gigamind.cognify.data.repository.UserRepository;
 import com.gigamind.cognify.data.firebase.FirebaseService;
+import com.gigamind.cognify.util.Constants;
 import com.gigamind.cognify.util.UserFields;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.snackbar.Snackbar;
@@ -37,8 +41,11 @@ public class ProfileFragment extends Fragment {
     private TextView userEmailText;
     private TextView userJoinedText;
     private ImageView settingsIcon;
+    private ImageView avatarImage;
     private TextView streakValueText;
     private TextView xpValueText;
+    private TextView gamesPlayedValue;
+    private TextView winRateValue;
     private Button inviteFriendsButton;
 
     private UserRepository userRepository;
@@ -61,13 +68,16 @@ public class ProfileFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         // 1) Bind all views
-        userNameText            = view.findViewById(R.id.userName);
-        userEmailText           = view.findViewById(R.id.userEmail);
-        userJoinedText          = view.findViewById(R.id.userJoined);
-        settingsIcon            = view.findViewById(R.id.settingsIcon);
-        streakValueText         = view.findViewById(R.id.streakValue);
-        xpValueText             = view.findViewById(R.id.xpValue);
-        inviteFriendsButton     = view.findViewById(R.id.inviteFriendsButton);
+        userNameText        = view.findViewById(R.id.userName);
+        userEmailText       = view.findViewById(R.id.userEmail);
+        userJoinedText      = view.findViewById(R.id.userJoined);
+        settingsIcon        = view.findViewById(R.id.settingsIcon);
+        avatarImage         = view.findViewById(R.id.avatarImage);
+        streakValueText     = view.findViewById(R.id.streakValue);
+        xpValueText         = view.findViewById(R.id.xpValue);
+        gamesPlayedValue    = view.findViewById(R.id.gamesPlayedValue);
+        winRateValue        = view.findViewById(R.id.winRateValue);
+        inviteFriendsButton = view.findViewById(R.id.inviteFriendsButton);
 
         // 2) Initialize FirebaseUser & UserRepository
         firebaseUser   = FirebaseService.getInstance().getCurrentUser();
@@ -101,8 +111,7 @@ public class ProfileFragment extends Fragment {
             } else {
                 userJoinedText.setText("");
             }
-
-            // TODO: if you store a profile‐picture URL, load it into ‘profileImageView’ here
+            applyAvatarCustomization();
         } else {
             // Guest user
             userNameText.setText(getString(R.string.guest));
@@ -115,6 +124,8 @@ public class ProfileFragment extends Fragment {
         // 1) Start with blank values—so nothing flickers before we get “cache or server” data
         streakValueText.setText("");
         xpValueText.setText("");
+        gamesPlayedValue.setText("");
+        winRateValue.setText("");
 
         if (firebaseUser != null) {
             // 2) Attach the Firestore listener
@@ -124,12 +135,19 @@ public class ProfileFragment extends Fragment {
                     // Firestore just updated SharedPreferences; read from there:
                     final int streak = userRepository.getCurrentStreak();
                     final int totalXp = userRepository.getTotalXP();
+                    final int games = userRepository.getTotalGames();
+                    final int wins = userRepository.getTotalWins();
+                    final int losses = userRepository.getTotalLosses();
 
                     // Always update UI on main thread
                     if (getActivity() != null) {
                         getActivity().runOnUiThread(() -> {
                             streakValueText.setText(String.valueOf(streak));
                             xpValueText.setText(String.valueOf(totalXp));
+                            gamesPlayedValue.setText(String.valueOf(games));
+                            int total = wins + losses;
+                            String rate = total > 0 ? (100 * wins / total) + "%" : "0%";
+                            winRateValue.setText(rate);
                         });
                     }
                 }
@@ -138,8 +156,15 @@ public class ProfileFragment extends Fragment {
             // 3) If not signed in, simply read local prefs once
             int streak  = userRepository.getCurrentStreak();
             int totalXp = userRepository.getTotalXP();
+            int games   = userRepository.getTotalGames();
+            int wins    = userRepository.getTotalWins();
+            int losses  = userRepository.getTotalLosses();
             streakValueText.setText(String.valueOf(streak));
             xpValueText.setText(String.valueOf(totalXp));
+            gamesPlayedValue.setText(String.valueOf(games));
+            int total = wins + losses;
+            String rate = total > 0 ? (100 * wins / total) + "%" : "0%";
+            winRateValue.setText(rate);
         }
     }
 
@@ -150,15 +175,41 @@ public class ProfileFragment extends Fragment {
             bottomNav.setSelectedItemId(R.id.navigation_settings);
         });
 
+        avatarImage.setOnClickListener(v ->
+                requireActivity().getSupportFragmentManager().beginTransaction()
+                        .replace(R.id.nav_host_fragment, new AvatarCustomizationFragment())
+                        .addToBackStack(null)
+                        .commit()
+        );
+
         inviteFriendsButton.setOnClickListener(v -> {
             Intent shareIntent = new Intent(Intent.ACTION_SEND);
             shareIntent.setType("text/plain");
-            shareIntent.putExtra(
-                    Intent.EXTRA_TEXT,
-                    getString(R.string.invite_message)
-            );
+            String friendCode = (firebaseUser != null) ? firebaseUser.getUid() : "guest";
+            String message = getString(R.string.invite_message) + "\nCode: " + friendCode;
+            shareIntent.putExtra(Intent.EXTRA_TEXT, message);
             startActivity(Intent.createChooser(shareIntent, getString(R.string.invite_chooser_title)));
         });
+    }
+
+    private void applyAvatarCustomization() {
+        SharedPreferences prefs = requireContext().getSharedPreferences(Constants.PREF_APP, Context.MODE_PRIVATE);
+        String frame = prefs.getString("avatar_frame", "Circle");
+        String color = prefs.getString("avatar_color", "Blue");
+
+        if (frame.equals("Square")) {
+            avatarImage.setBackgroundResource(R.drawable.avatar_frame_square);
+        } else {
+            avatarImage.setBackgroundResource(R.drawable.avatar_frame_circle);
+        }
+
+        if (color.equals("Green")) {
+            avatarImage.setColorFilter(getResources().getColor(R.color.success));
+        } else if (color.equals("Red")) {
+            avatarImage.setColorFilter(getResources().getColor(R.color.error));
+        } else {
+            avatarImage.setColorFilter(getResources().getColor(R.color.blue));
+        }
     }
 
     @Override

--- a/app/src/main/res/drawable/avatar_frame_circle.xml
+++ b/app/src/main/res/drawable/avatar_frame_circle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="@android:color/transparent" />
+    <stroke android:width="2dp" android:color="@color/gold" />
+</shape>

--- a/app/src/main/res/drawable/avatar_frame_square.xml
+++ b/app/src/main/res/drawable/avatar_frame_square.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/transparent" />
+    <stroke android:width="2dp" android:color="@color/info" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_avatar_customization.xml
+++ b/app/src/main/res/layout/fragment_avatar_customization.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <ImageView
+        android:id="@+id/avatarPreview"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:layout_gravity="center_horizontal"
+        android:src="@drawable/ic_avatar" />
+
+    <Spinner
+        android:id="@+id/frameSpinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp" />
+
+    <Spinner
+        android:id="@+id/hatSpinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp" />
+
+    <Spinner
+        android:id="@+id/colorSpinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp" />
+
+    <Button
+        android:id="@+id/saveAvatarButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/save" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -74,6 +74,13 @@
             android:orientation="vertical"
             android:padding="16dp">
 
+            <ImageView
+                android:id="@+id/avatarImage"
+                android:layout_width="72dp"
+                android:layout_height="72dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_avatar" />
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -232,7 +239,7 @@
                     </LinearLayout>
                 </LinearLayout>
 
-                <!-- Custom Tile 3 -->
+                <!-- Games Played Tile -->
                 <LinearLayout
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -241,24 +248,25 @@
                     android:layout_margin="8dp"
                     android:background="@drawable/profile_page_block_background"
                     android:orientation="vertical"
-                    android:padding="16dp"
-                    android:visibility="gone">
-
-                    <ImageView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:src="@drawable/icon_flash" />
+                    android:padding="16dp">
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:id="@+id/gamesPlayedValue"
+                        style="@style/ProfilePageUserNameStyle"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:text="@string/league"
-                        android:textAppearance="?attr/textAppearanceListItem" />
+                        android:gravity="center"
+                        android:text="0" />
+
+                    <TextView
+                        style="@style/ProfilePageSubtitleStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:text="@string/games_played" />
                 </LinearLayout>
 
-                <!-- Custom Tile 4 -->
+                <!-- Win Rate Tile -->
                 <LinearLayout
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -267,21 +275,22 @@
                     android:layout_margin="8dp"
                     android:background="@drawable/profile_page_block_background"
                     android:orientation="vertical"
-                    android:padding="16dp"
-                    android:visibility="gone">
-
-                    <ImageView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:src="@drawable/icon_flash" />
+                    android:padding="16dp">
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:id="@+id/winRateValue"
+                        style="@style/ProfilePageUserNameStyle"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:text="@string/tile_four"
-                        android:textAppearance="?attr/textAppearanceListItem" />
+                        android:gravity="center"
+                        android:text="0%" />
+
+                    <TextView
+                        style="@style/ProfilePageSubtitleStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:text="@string/win_rate" />
                 </LinearLayout>
 
             </GridLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,4 +151,10 @@
         Join me on Cognify! Download on Play Store: https://example.com/app
     </string>
     <string name="invite_chooser_title">Invite Friends</string>
+    <string name="save">Save</string>
+    <string name="customize_avatar">Customize Avatar</string>
+    <string name="frame">Frame</string>
+    <string name="hat">Hat</string>
+    <string name="color">Color</string>
+    <string name="win_rate">Win Rate</string>
 </resources>


### PR DESCRIPTION
## Summary
- introduce avatar customization fragment
- track games played and win/loss ratio
- display new stats and avatar image in profile screen
- support sharing friend code via invite button

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68508791eb6c8332aa083f8c50a3ab1a