### PR TITLE
Add crash reporting and onboarding analytics

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,21 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: gradle
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     id("com.google.gms.google-services")
+    id("com.google.firebase.crashlytics")
 }
 
 android {
@@ -46,6 +47,7 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.firebase:firebase-firestore")
+    implementation("com.google.firebase:firebase-crashlytics")
     
     // Lottie for animations
     implementation("com.airbnb.android:lottie:6.4.0")

--- a/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
+++ b/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
@@ -14,6 +14,7 @@ import com.gigamind.cognify.work.StreakNotificationScheduler;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.gigamind.cognify.engine.DictionaryProvider;
@@ -48,6 +49,7 @@ public class CognifyApplication extends Application {
 
         // (1) Initialize Firebase
         FirebaseApp.initializeApp(this);
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true);
 
         // (1b) Preload dictionary (so WordDashActivity doesn't flash an empty grid)
         DictionaryProvider.preloadDictionary(this);

--- a/app/src/main/java/com/gigamind/cognify/analytics/GameAnalytics.java
+++ b/app/src/main/java/com/gigamind/cognify/analytics/GameAnalytics.java
@@ -178,6 +178,21 @@ public class GameAnalytics {
         firebaseAnalytics.logEvent("daily_challenge_completed", bundle);
     }
 
+    // Onboarding Analytics
+    public void logOnboardingPage(int page) {
+        Bundle bundle = new Bundle();
+        bundle.putInt("page", page);
+        firebaseAnalytics.logEvent("onboarding_page", bundle);
+    }
+
+    public void logOnboardingCompleted() {
+        firebaseAnalytics.logEvent("onboarding_completed", null);
+    }
+
+    public void logOnboardingSkipped() {
+        firebaseAnalytics.logEvent("onboarding_skipped", null);
+    }
+
     // Navigation Analytics
     public void logScreenView(String screenName) {
         Bundle bundle = new Bundle();

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ activity = "1.9.2"
 constraintlayout = "2.1.4"
 googleGmsGoogleServices = "4.4.2"
 firebaseAnalytics = "22.4.0"
+firebaseCrashlyticsGradle = "2.9.9"
 navigationRuntimeAndroid = "2.9.0"
 navigationUi = "2.9.0"
 navVersion = "2.7.7"
@@ -47,4 +48,5 @@ circleimageview = { module = "de.hdodenhof:circleimageview", version.ref = "circ
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 google-gms-google-services = { id = "com.google.gms.google-services", version.ref = "googleGmsGoogleServices" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsGradle" }
 


### PR DESCRIPTION
## Summary
- include Crashlytics plugin and dependency
- track onboarding progress in analytics
- enable Crashlytics at app startup
- add GitHub Actions workflow for CI

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685087d151bc8332a428c7c2ccbb570c