### PR TITLE
Update badges to new level names

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/util/BadgeUtils.java
+++ b/app/src/main/java/com/gigamind/cognify/util/BadgeUtils.java
@@ -6,13 +6,36 @@ import androidx.annotation.NonNull;
 public final class BadgeUtils {
     private BadgeUtils() {}
 
+    /**
+     * XP thresholds for the different badge tiers. The values map directly
+     * to the levels defined in {@code levels.txt} in the project root.
+     * <p>
+     * Each index corresponds to a badge tier defined in {@link #NAMES} and
+     * {@link #ICONS}.
+     */
     public static final int[] THRESHOLDS = {
-            0, 500, 1000, 1500, 2000, 3000, 4000, 5000, 7000, 9000
+            0, 10000, 20000, 30000, 40000,
+            50000, 60000, 70000, 80000, 90000
     };
 
+    /** Names of the badge tiers displayed to the user. */
     public static final String[] NAMES = {
-            "Rookie", "Apprentice", "Adept", "Expert", "Veteran",
-            "Elite", "Master", "Champion", "Hero", "Legend"
+            "Rookie", "Learner", "Thinker", "Solver", "Challenger",
+            "Strategist", "Brainiac", "Genius", "Mastermind", "Legend"
+    };
+
+    /** Drawable resources for each badge tier. */
+    private static final int[] ICONS = {
+            com.gigamind.cognify.R.drawable.rookie,
+            com.gigamind.cognify.R.drawable.learner,
+            com.gigamind.cognify.R.drawable.thinker,
+            com.gigamind.cognify.R.drawable.solver,
+            com.gigamind.cognify.R.drawable.challenger,
+            com.gigamind.cognify.R.drawable.strategist,
+            com.gigamind.cognify.R.drawable.brainiac,
+            com.gigamind.cognify.R.drawable.genius,
+            com.gigamind.cognify.R.drawable.mastermind,
+            com.gigamind.cognify.R.drawable.legend
     };
 
     /** Returns the badge index (0..9) for the given total XP. */
@@ -34,8 +57,16 @@ public final class BadgeUtils {
         return NAMES[badgeIndexForXp(xp)];
     }
 
-    /** Returns the drawable resource for the given badge index. */
+    /**
+     * Returns the drawable resource for the given badge index. If the index is
+     * out of range, the last badge (Legend) is returned as a fallback.
+     */
     public static int badgeIconResId(int index) {
-        return com.gigamind.cognify.R.drawable.ic_badge; // placeholder
+        if (index < 0) {
+            index = 0;
+        } else if (index >= ICONS.length) {
+            index = ICONS.length - 1;
+        }
+        return ICONS[index];
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,14 +174,14 @@
     <!-- Trophy Room -->
     <string name="trophy_room">Trophy Room</string>
     <string name="badge_rookie">Rookie</string>
-    <string name="badge_apprentice">Apprentice</string>
-    <string name="badge_adept">Adept</string>
-    <string name="badge_expert">Expert</string>
-    <string name="badge_veteran">Veteran</string>
-    <string name="badge_elite">Elite</string>
-    <string name="badge_master">Master</string>
-    <string name="badge_champion">Champion</string>
-    <string name="badge_hero">Hero</string>
+    <string name="badge_learner">Learner</string>
+    <string name="badge_thinker">Thinker</string>
+    <string name="badge_solver">Solver</string>
+    <string name="badge_challenger">Challenger</string>
+    <string name="badge_strategist">Strategist</string>
+    <string name="badge_brainiac">Brainiac</string>
+    <string name="badge_genius">Genius</string>
+    <string name="badge_mastermind">Mastermind</string>
     <string name="badge_legend">Legend</string>
     <string name="daily_quest">Daily Quest</string>
     <string name="quest_reward">Reward: %1$s</string>

--- a/app/src/test/java/com/gigamind/cognify/ui/leaderboard/LeaderboardItemTest.java
+++ b/app/src/test/java/com/gigamind/cognify/ui/leaderboard/LeaderboardItemTest.java
@@ -9,15 +9,15 @@ public class LeaderboardItemTest {
     @ParameterizedTest
     @CsvSource({
             "0,Rookie",
-            "500,Apprentice",
-            "1200,Adept",
-            "1600,Expert",
-            "2500,Veteran",
-            "3500,Elite",
-            "4500,Master",
-            "5200,Champion",
-            "7500,Hero",
-            "9500,Legend"
+            "10000,Learner",
+            "20000,Thinker",
+            "30000,Solver",
+            "40000,Challenger",
+            "50000,Strategist",
+            "60000,Brainiac",
+            "70000,Genius",
+            "80000,Mastermind",
+            "90000,Legend"
     })
     void badgeTypeMatchesXpThreshold(int xp, String expected) {
         LeaderboardItem item = new LeaderboardItem("id", "name", xp, "US");


### PR DESCRIPTION
## Summary
- update badge thresholds and names in `BadgeUtils`
- return specific badge icons for each level
- update trophy room strings with new badge names
- adjust leaderboard test for new badge levels

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850910fdf1c8332a17b2106a8e71424