### PR TITLE
Refactor notification workers

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/util/NotificationUtils.java
+++ b/app/src/main/java/com/gigamind/cognify/util/NotificationUtils.java
@@ -2,8 +2,12 @@ package com.gigamind.cognify.util;
 
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Build;
+
+import androidx.core.app.NotificationCompat;
 
 /** Helper methods for notification related operations. */
 public final class NotificationUtils {
@@ -27,6 +31,46 @@ public final class NotificationUtils {
             if (nm != null) {
                 nm.createNotificationChannel(channel);
             }
+        }
+    }
+
+    /**
+     * Sends a simple notification that launches the given Activity when tapped.
+     */
+    public static void sendNotification(
+            Context context,
+            String channelId,
+            int iconRes,
+            String title,
+            String text,
+            Class<?> activityClass,
+            int notificationId
+    ) {
+        Intent intent = new Intent(context, activityClass);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+
+        PendingIntent pi = PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT
+                        | (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                        ? PendingIntent.FLAG_IMMUTABLE
+                        : 0)
+        );
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channelId)
+                .setSmallIcon(iconRes)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setAutoCancel(true)
+                .setContentIntent(pi);
+
+        NotificationManager nm =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm != null) {
+            nm.notify(notificationId, builder.build());
         }
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/work/QuestNotificationWorker.java
+++ b/app/src/main/java/com/gigamind/cognify/work/QuestNotificationWorker.java
@@ -1,12 +1,8 @@
 package com.gigamind.cognify.work;
 
-import android.app.PendingIntent;
 import android.content.Context;
-import android.content.Intent;
-import android.os.Build;
 
 import androidx.annotation.NonNull;
-import androidx.core.app.NotificationCompat;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
@@ -40,32 +36,15 @@ public class QuestNotificationWorker extends Worker {
                 android.app.NotificationManager.IMPORTANCE_HIGH
         );
 
-        Intent toMain = new Intent(context, MainActivity.class);
-        toMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-
-        PendingIntent pi = PendingIntent.getActivity(
+        NotificationUtils.sendNotification(
                 context,
-                0,
-                toMain,
-                PendingIntent.FLAG_UPDATE_CURRENT
-                        | (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-                        ? PendingIntent.FLAG_IMMUTABLE
-                        : 0)
+                CHANNEL_ID,
+                R.drawable.ic_streak,
+                context.getString(R.string.notif_quest_title),
+                context.getString(R.string.notif_quest_text),
+                MainActivity.class,
+                NOTIF_ID
         );
-
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
-                .setSmallIcon(R.drawable.ic_streak)
-                .setContentTitle(context.getString(R.string.notif_quest_title))
-                .setContentText(context.getString(R.string.notif_quest_text))
-                .setAutoCancel(true)
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .setContentIntent(pi);
-
-        NotificationManager nm =
-                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        if (nm != null) {
-            nm.notify(NOTIF_ID, builder.build());
-        }
     }
 
 }

--- a/app/src/main/java/com/gigamind/cognify/work/StreakNotificationWorker.java
+++ b/app/src/main/java/com/gigamind/cognify/work/StreakNotificationWorker.java
@@ -1,13 +1,9 @@
 package com.gigamind.cognify.work;
 
-import android.app.PendingIntent;
 import android.content.Context;
-import android.content.Intent;
-import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import androidx.core.app.NotificationCompat;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
@@ -86,32 +82,15 @@ public class StreakNotificationWorker extends Worker {
                 android.app.NotificationManager.IMPORTANCE_HIGH
         );
 
-        Intent toMain = new Intent(context, MainActivity.class);
-        toMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-
-        PendingIntent pi = PendingIntent.getActivity(
+        NotificationUtils.sendNotification(
                 context,
-                0,
-                toMain,
-                PendingIntent.FLAG_UPDATE_CURRENT
-                        | (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-                        ? PendingIntent.FLAG_IMMUTABLE
-                        : 0)
+                CHANNEL_ID,
+                R.drawable.ic_streak,
+                context.getString(R.string.notif_streak_title),
+                context.getString(R.string.notif_streak_text),
+                MainActivity.class,
+                NOTIF_ID
         );
-
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
-                .setSmallIcon(R.drawable.ic_streak)
-                .setContentTitle(context.getString(R.string.notif_streak_title))
-                .setContentText(context.getString(R.string.notif_streak_text))
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .setAutoCancel(true)
-                .setContentIntent(pi);
-
-        NotificationManager nm =
-                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        if (nm != null) {
-            nm.notify(NOTIF_ID, builder.build());
-        }
     }
 
 }


### PR DESCRIPTION
## Summary
- consolidate repeated notification code into NotificationUtils
- use new helper from Quest/Streak workers

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685095347408833282a325731dd79229