### PR TITLE
Update Quick Math layout

### DIFF
--- a/app/src/main/res/layout/activity_quick_math.xml
+++ b/app/src/main/res/layout/activity_quick_math.xml
@@ -75,12 +75,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/titleBar" />
 
-    <LinearLayout
+    <GridLayout
         android:id="@+id/answersLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="64dp"
-        android:orientation="vertical"
+        android:columnCount="2"
+        android:rowCount="2"
+        android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/equationText"
@@ -88,9 +90,12 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer1Button"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
             android:layout_marginBottom="16dp"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
             android:backgroundTint="@color/button_background"
             android:padding="16dp"
             android:textColor="@color/text_primary"
@@ -98,9 +103,12 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer2Button"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
             android:layout_marginBottom="16dp"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
             android:backgroundTint="@color/button_background"
             android:padding="16dp"
             android:textColor="@color/text_primary"
@@ -108,9 +116,11 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer3Button"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
+            android:layout_marginEnd="8dp"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
             android:backgroundTint="@color/button_background"
             android:padding="16dp"
             android:textColor="@color/text_primary"
@@ -118,13 +128,15 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer4Button"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_columnWeight="1"
+            android:layout_rowWeight="1"
             android:backgroundTint="@color/button_background"
             android:padding="16dp"
             android:textColor="@color/text_primary"
             android:textSize="24sp" />
-
-    </LinearLayout>
+    </GridLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- display Quick Math answer buttons in a 2x2 `GridLayout`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850990c713883329b4757b3fd561cc1