### PR TITLE
Add Word Dash tutorial overlay

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
@@ -1,0 +1,89 @@
+package com.gigamind.cognify.ui;
+
+import android.app.Activity;
+import android.graphics.Point;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.PopupWindow;
+import android.widget.TextView;
+
+import com.gigamind.cognify.R;
+import com.google.android.material.button.MaterialButton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple sequential popup tutorial overlay.
+ */
+public class TutorialOverlay {
+    private final Activity activity;
+    private final List<Step> steps = new ArrayList<>();
+    private int index = 0;
+    private PopupWindow popup;
+    private Runnable onComplete;
+
+    public TutorialOverlay(Activity activity) {
+        this.activity = activity;
+    }
+
+    private static class Step {
+        final View anchor;
+        final String text;
+        Step(View anchor, String text) {
+            this.anchor = anchor;
+            this.text = text;
+        }
+    }
+
+    public void addStep(View anchor, String text) {
+        steps.add(new Step(anchor, text));
+    }
+
+    public void setOnComplete(Runnable r) {
+        onComplete = r;
+    }
+
+    public void start() {
+        if (steps.isEmpty()) return;
+        index = 0;
+        showStep();
+    }
+
+    private void showStep() {
+        Step step = steps.get(index);
+        View view = LayoutInflater.from(activity).inflate(R.layout.tutorial_popup, null);
+        TextView text = view.findViewById(R.id.tutorialText);
+        MaterialButton next = view.findViewById(R.id.tutorialNextButton);
+        text.setText(step.text);
+        next.setText(index == steps.size() - 1 ? activity.getString(R.string.tutorial_got_it)
+                : activity.getString(R.string.tutorial_next));
+        popup = new PopupWindow(view,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                true);
+        popup.setOutsideTouchable(false);
+        popup.setFocusable(true);
+        int[] loc = new int[2];
+        step.anchor.getLocationInWindow(loc);
+        Point size = new Point();
+        activity.getWindowManager().getDefaultDisplay().getSize(size);
+        view.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
+        int popupHeight = view.getMeasuredHeight();
+        int y = loc[1] - popupHeight;
+        if (y < 0) y = loc[1] + step.anchor.getHeight();
+        popup.showAtLocation(step.anchor, Gravity.NO_GRAVITY, loc[0], y);
+
+        next.setOnClickListener(v -> {
+            popup.dismiss();
+            index++;
+            if (index < steps.size()) {
+                showStep();
+            } else if (onComplete != null) {
+                onComplete.run();
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -24,6 +24,7 @@ import com.gigamind.cognify.util.GameConfig;
 import com.gigamind.cognify.util.GameType;
 import com.gigamind.cognify.util.GameTimer;
 import com.gigamind.cognify.util.TutorialHelper;
+import com.gigamind.cognify.ui.TutorialOverlay;
 import com.google.android.flexbox.FlexDirection;
 import com.google.android.flexbox.FlexWrap;
 import com.google.android.flexbox.FlexboxLayoutManager;
@@ -53,6 +54,8 @@ public class WordDashActivity extends AppCompatActivity {
     private long wordStartTime;
     private TutorialHelper tutorialHelper;
     private boolean tutorialActive = false;
+    private TutorialOverlay tutorialOverlay;
+    private MaterialButton submitButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -94,7 +97,15 @@ public class WordDashActivity extends AppCompatActivity {
                         isDictionaryLoaded = true;
                         if (!tutorialHelper.isTutorialCompleted()) {
                             tutorialActive = true;
-                            Toast.makeText(this, R.string.tutorial_start_hint, Toast.LENGTH_LONG).show();
+                            tutorialOverlay = new TutorialOverlay(this);
+                            tutorialOverlay.addStep(letterGrid, getString(R.string.tutorial_step_letters));
+                            tutorialOverlay.addStep(submitButton, getString(R.string.tutorial_step_submit));
+                            tutorialOverlay.setOnComplete(() -> {
+                                Toast.makeText(this, R.string.tutorial_complete, Toast.LENGTH_SHORT).show();
+                                tutorialHelper.markTutorialCompleted();
+                                tutorialActive = false;
+                            });
+                            letterGrid.post(tutorialOverlay::start);
                         }
                         startGame();       // Begin the game timer
                     } else {
@@ -115,7 +126,7 @@ public class WordDashActivity extends AppCompatActivity {
     }
 
     private void setupButtons() {
-        MaterialButton submitButton = findViewById(R.id.submitButton);
+        submitButton = findViewById(R.id.submitButton);
         MaterialButton clearButton = findViewById(R.id.clearButton);
         MaterialButton backspaceButton = findViewById(R.id.backspaceButton);
 

--- a/app/src/main/res/drawable/bg_tooltip.xml
+++ b/app/src/main/res/drawable/bg_tooltip.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/card_background" />
+    <corners android:radius="8dp" />
+    <padding android:left="8dp" android:top="8dp" android:right="8dp" android:bottom="8dp"/>
+</shape>

--- a/app/src/main/res/layout/tutorial_popup.xml
+++ b/app/src/main/res/layout/tutorial_popup.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="8dp"
+    android:background="@drawable/bg_tooltip"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/tutorialText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/black"
+        android:textSize="16sp"
+        android:padding="4dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/tutorialNextButton"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/tutorial_next" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,6 +192,10 @@
     <string name="play_tip">You\u2019ll see a quick tutorial first.</string>
     <string name="tutorial_start_hint">Tap letters to form a word, then hit Submit.</string>
     <string name="tutorial_complete">Great! Tutorial complete.</string>
+    <string name="tutorial_step_letters">Tap letters to form a word.</string>
+    <string name="tutorial_step_submit">Tap Submit when you're done.</string>
+    <string name="tutorial_next">Next</string>
+    <string name="tutorial_got_it">Got it!</string>
 
     <string name="delete_account">Delete Account</string>
     <string name="delete_account_confirm">This will permanently delete your account and all data. Continue?</string>


### PR DESCRIPTION
## Summary
- create sequential tutorial overlay popup
- show interactive hints when Word Dash first launches
- add supporting layout, drawable and strings

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68509ac5a25883328ec2e2da0752ea8f