### PR TITLE
Improve tutorial overlay design

### DIFF
--- a/app/src/main/res/drawable/bg_tooltip.xml
+++ b/app/src/main/res/drawable/bg_tooltip.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/card_background" />
-    <corners android:radius="8dp" />
-    <padding android:left="8dp" android:top="8dp" android:right="8dp" android:bottom="8dp"/>
-</shape>

--- a/app/src/main/res/layout/tutorial_popup.xml
+++ b/app/src/main/res/layout/tutorial_popup.xml
@@ -1,23 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:padding="8dp"
-    android:background="@drawable/bg_tooltip"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    android:backgroundTint="@color/card_background"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="6dp"
+    app:strokeColor="@color/primary"
+    app:strokeWidth="1dp">
 
-    <TextView
-        android:id="@+id/tutorialText"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textColor="@color/black"
-        android:textSize="16sp"
-        android:padding="4dp" />
+        android:orientation="vertical"
+        android:padding="16dp">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/tutorialNextButton"
-        style="@style/Widget.Material3.Button.TextButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/tutorial_next" />
-</LinearLayout>
+        <TextView
+            android:id="@+id/tutorialText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingBottom="12dp"
+            android:textColor="@color/black"
+            android:textSize="18sp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tutorialNextButton"
+            style="@style/Button.Enabled"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/tutorial_next" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- redesign the tutorial popup to use a MaterialCardView
- enlarge the text and next button
- remove the old `bg_tooltip` drawable

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68509f97381c8332a7d5710a7f53b253