### PR TITLE
Prevent accidental tutorial dismissal

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
@@ -57,15 +57,15 @@ public class TutorialOverlay {
         View view = LayoutInflater.from(activity).inflate(R.layout.tutorial_popup, null);
         TextView text = view.findViewById(R.id.tutorialText);
         MaterialButton next = view.findViewById(R.id.tutorialNextButton);
+        MaterialButton skip = view.findViewById(R.id.tutorialSkipButton);
         text.setText(step.text);
         next.setText(index == steps.size() - 1 ? activity.getString(R.string.tutorial_got_it)
                 : activity.getString(R.string.tutorial_next));
         popup = new PopupWindow(view,
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT,
-                true);
+                false);
         popup.setOutsideTouchable(false);
-        popup.setFocusable(true);
         int[] loc = new int[2];
         step.anchor.getLocationInWindow(loc);
         Point size = new Point();
@@ -82,6 +82,14 @@ public class TutorialOverlay {
             if (index < steps.size()) {
                 showStep();
             } else if (onComplete != null) {
+                onComplete.run();
+            }
+        });
+
+        skip.setOnClickListener(v -> {
+            popup.dismiss();
+            index = steps.size();
+            if (onComplete != null) {
                 onComplete.run();
             }
         });

--- a/app/src/main/res/layout/tutorial_popup.xml
+++ b/app/src/main/res/layout/tutorial_popup.xml
@@ -30,5 +30,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/tutorial_next" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tutorialSkipButton"
+            style="@style/Button.Disabled"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/tutorial_skip" />
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,6 +202,7 @@
     <string name="tutorial_step_clear">Clear your entire word with this.</string>
     <string name="tutorial_next">Next</string>
     <string name="tutorial_got_it">Got it!</string>
+    <string name="tutorial_skip">Skip Tutorial</string>
 
     <string name="delete_account">Delete Account</string>
     <string name="delete_account_confirm">This will permanently delete your account and all data. Continue?</string>


### PR DESCRIPTION
## Summary
- prevent TutorialOverlay from dismissing when tapping outside
- add a Skip Tutorial button to the overlay layout
- handle skip events in TutorialOverlay
- add string resource for skip button

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850a122a9148332bd61c426deec4c47