### PR TITLE
Fix tutorial skip button visibility

### DIFF
--- a/app/src/main/res/layout/tutorial_popup.xml
+++ b/app/src/main/res/layout/tutorial_popup.xml
@@ -33,7 +33,7 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/tutorialSkipButton"
-            style="@style/Button.Disabled"
+            style="@style/Button.Skip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -73,6 +73,17 @@
         <item name="elevation">2dp</item>
     </style>
 
+    <!-- Skip Button style to ensure visibility on light backgrounds -->
+    <style name="Button.Skip" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="android:textColor">@color/primary</item>
+        <item name="android:textSize">16sp</item>
+        <item name="android:padding">14dp</item>
+        <item name="android:letterSpacing">0.025</item>
+        <item name="cornerRadius">100dp</item>
+        <item name="strokeColor">@color/primary</item>
+        <item name="elevation">2dp</item>
+    </style>
+
     <!-- Letter Button style -->
     <style name="Button.Letter" parent="Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:textColor">@color/text_white</item>


### PR DESCRIPTION
## Summary
- ensure skip button text is visible against light card background
- use new `Button.Skip` style in tutorial popup

## Testing
- `./gradlew test` *(fails: Unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6850a25c0af08332b65bae71708c2e29