### PR TITLE
Highlight focused tutorial elements

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
@@ -36,9 +36,12 @@ public class TutorialOverlay {
     private static class Step {
         final View anchor;
         final String text;
+        final float originalElevation;
+
         Step(View anchor, String text) {
             this.anchor = anchor;
             this.text = text;
+            this.originalElevation = anchor.getElevation();
         }
     }
 
@@ -69,7 +72,9 @@ public class TutorialOverlay {
         if (scrim.getParent() == null) {
             root.addView(scrim, new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
         }
+        scrim.setElevation(1f);
         step.anchor.bringToFront();
+        step.anchor.setElevation(step.originalElevation + 10f);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             step.anchor.setForeground(ContextCompat.getDrawable(activity, R.drawable.tutorial_highlight));
         }
@@ -123,8 +128,11 @@ public class TutorialOverlay {
     }
 
     private void clearHighlight() {
-        if (currentStep != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            currentStep.anchor.setForeground(null);
+        if (currentStep != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                currentStep.anchor.setForeground(null);
+            }
+            currentStep.anchor.setElevation(currentStep.originalElevation);
         }
     }
 }


### PR DESCRIPTION
## Summary
- highlight target view during tutorial steps by raising elevation
- keep the target element's original elevation once tutorial ends

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850a51692a48332bd95b32ebfaa4134