### PR TITLE
Delay timer until tutorial complete

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -112,10 +112,12 @@ public class WordDashActivity extends AppCompatActivity {
                                 Toast.makeText(this, R.string.tutorial_complete, Toast.LENGTH_SHORT).show();
                                 tutorialHelper.markTutorialCompleted();
                                 tutorialActive = false;
+                                startGame();
                             });
                             letterGrid.post(tutorialOverlay::start);
+                        } else {
+                            startGame();       // Begin the game timer immediately
                         }
-                        startGame();       // Begin the game timer
                     } else {
                         // Handle dictionary load error
                         Toast.makeText(this, "Error loading game dictionary", Toast.LENGTH_LONG).show();
@@ -409,7 +411,7 @@ public class WordDashActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        if (isDictionaryLoaded && gameTimer == null) {
+        if (isDictionaryLoaded && gameTimer == null && !tutorialActive) {
             startGame();
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,7 +201,7 @@
     <string name="tutorial_step_back">Use Back to remove the last letter.</string>
     <string name="tutorial_step_clear">Clear your entire word with this.</string>
     <string name="tutorial_next">Next</string>
-    <string name="tutorial_got_it">Got it!</string>
+    <string name="tutorial_got_it">Start Game</string>
     <string name="tutorial_skip">Skip Tutorial</string>
 
     <string name="delete_account">Delete Account</string>


### PR DESCRIPTION
## Summary
- update WordDash tutorial to start the timer only after tutorial completion or skip
- change last tutorial button text to "Start Game"

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6850a7125dac8332adcc5677ae30545b