### PR TITLE
Fix tutorial highlight misalignment

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/HighlightScrimView.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/HighlightScrimView.java
@@ -21,6 +21,7 @@ import com.gigamind.cognify.R;
 public class HighlightScrimView extends View {
     private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private RectF holeRect;
+    private final float cornerRadius;
 
     public HighlightScrimView(Context context) {
         this(context, null);
@@ -30,6 +31,7 @@ public class HighlightScrimView extends View {
         super(context, attrs);
         paint.setColor(ContextCompat.getColor(context, R.color.scrim));
         setLayerType(LAYER_TYPE_HARDWARE, null);
+        cornerRadius = 8f * getResources().getDisplayMetrics().density;
     }
 
     public void setHole(RectF rect) {
@@ -45,7 +47,7 @@ public class HighlightScrimView extends View {
         if (holeRect != null) {
             Paint clearPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
             clearPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
-            canvas.drawRoundRect(holeRect, 16f, 16f, clearPaint);
+            canvas.drawRoundRect(holeRect, cornerRadius, cornerRadius, clearPaint);
         }
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
@@ -92,11 +92,14 @@ public class TutorialOverlay {
         popup.setOutsideTouchable(false);
         int[] loc = new int[2];
         step.anchor.getLocationInWindow(loc);
+        int[] rootLoc = new int[2];
+        root.getLocationInWindow(rootLoc);
+
         RectF hole = new RectF(
-                loc[0],
-                loc[1],
-                loc[0] + step.anchor.getWidth(),
-                loc[1] + step.anchor.getHeight());
+                loc[0] - rootLoc[0],
+                loc[1] - rootLoc[1],
+                loc[0] - rootLoc[0] + step.anchor.getWidth(),
+                loc[1] - rootLoc[1] + step.anchor.getHeight());
         scrim.setHole(hole);
         view.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
         int popupHeight = view.getMeasuredHeight();


### PR DESCRIPTION
## Summary
- fix coordinate calculations for tutorial overlay highlights
- match highlight scrim corner radius to green outline

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --no-daemon` *(fails: Unable to tunnel through proxy)*


------
https://chatgpt.com/codex/tasks/task_e_6850a91a0a0883329cac7388dbd17753