### PR TITLE
Fix Word Dash tutorial layout shift

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
@@ -73,7 +73,9 @@ public class TutorialOverlay {
             root.addView(scrim, new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
         }
         scrim.setElevation(1f);
-        step.anchor.bringToFront();
+        // Use elevation to show the highlight above the scrim without altering
+        // the child's position within its parent layout. Calling bringToFront()
+        // caused layout reordering which shifted views in LinearLayouts.
         step.anchor.setElevation(step.originalElevation + 10f);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             step.anchor.setForeground(ContextCompat.getDrawable(activity, R.drawable.tutorial_highlight));


### PR DESCRIPTION
## Summary
- fix tutorial overlay not resetting element order

## Testing
- `./gradlew testDebugUnitTest` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850aaabe6ac8332b8a4ca3e3d737405