### PR TITLE
Update tutorial layout for side-by-side buttons

### DIFF
--- a/app/src/main/res/layout/tutorial_popup.xml
+++ b/app/src/main/res/layout/tutorial_popup.xml
@@ -24,19 +24,27 @@
             android:textColor="@color/black"
             android:textSize="18sp" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/tutorialNextButton"
-            style="@style/Button.Enabled"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/tutorial_next" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/tutorialSkipButton"
-            style="@style/Button.Skip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:orientation="horizontal"
             android:layout_marginTop="8dp"
-            android:text="@string/tutorial_skip" />
+            android:gravity="end">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/tutorialSkipButton"
+                style="@style/Button.Skip"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/tutorial_skip" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/tutorialNextButton"
+                style="@style/Button.Enabled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/tutorial_next" />
+        </LinearLayout>
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- align `Skip` and `Next` buttons side by side inside tutorial popup

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850ab7c17dc83329f0910febd40e4a5