### PR TITLE
Improve avatar customization flow

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/profile/AvatarCustomizationFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/AvatarCustomizationFragment.java
@@ -10,6 +10,7 @@ import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.Spinner;
 import android.widget.Button;
+import android.widget.AdapterView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -54,6 +55,20 @@ public class AvatarCustomizationFragment extends Fragment {
         setupSpinners();
         loadSelections();
 
+        // Update preview whenever an option is changed
+        AdapterView.OnItemSelectedListener listener = new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view1, int position, long id) {
+                updatePreview();
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {}
+        };
+        frameSpinner.setOnItemSelectedListener(listener);
+        hatSpinner.setOnItemSelectedListener(listener);
+        colorSpinner.setOnItemSelectedListener(listener);
+
         saveButton.setOnClickListener(v -> {
             prefs.edit()
                     .putString(KEY_AVATAR_FRAME, frameSpinner.getSelectedItem().toString())
@@ -92,5 +107,25 @@ public class AvatarCustomizationFragment extends Fragment {
         frameSpinner.setSelection(frame.equals("Square") ? 1 : 0);
         hatSpinner.setSelection(hat.equals("Crown") ? 1 : hat.equals("Cap") ? 2 : 0);
         colorSpinner.setSelection(color.equals("Green") ? 1 : color.equals("Red") ? 2 : 0);
+        updatePreview();
+    }
+
+    private void updatePreview() {
+        String frame = frameSpinner.getSelectedItem().toString();
+        String color = colorSpinner.getSelectedItem().toString();
+
+        if (frame.equals("Square")) {
+            avatarPreview.setBackgroundResource(R.drawable.avatar_frame_square);
+        } else {
+            avatarPreview.setBackgroundResource(R.drawable.avatar_frame_circle);
+        }
+
+        if (color.equals("Green")) {
+            avatarPreview.setColorFilter(getResources().getColor(R.color.success));
+        } else if (color.equals("Red")) {
+            avatarPreview.setColorFilter(getResources().getColor(R.color.error));
+        } else {
+            avatarPreview.setColorFilter(getResources().getColor(R.color.blue));
+        }
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -232,6 +232,13 @@ public class ProfileFragment extends Fragment {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        // Refresh avatar in case customization changed while this fragment was paused
+        applyAvatarCustomization();
+    }
+
+    @Override
     public void onDestroyView() {
         super.onDestroyView();
         // Always remove the Firestore listener to prevent memory leaks

--- a/app/src/main/res/layout/fragment_avatar_customization.xml
+++ b/app/src/main/res/layout/fragment_avatar_customization.xml
@@ -12,23 +12,41 @@
         android:layout_gravity="center_horizontal"
         android:src="@drawable/ic_avatar" />
 
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/frame"
+        android:textStyle="bold" />
+
     <Spinner
         android:id="@+id/frameSpinner"
         android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp" />
+        android:layout_marginTop="16dp"
+        android:text="@string/hat"
+        android:textStyle="bold" />
 
     <Spinner
         android:id="@+id/hatSpinner"
         android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp" />
+        android:layout_marginTop="16dp"
+        android:text="@string/color"
+        android:textStyle="bold" />
 
     <Spinner
         android:id="@+id/colorSpinner"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp" />
+        android:layout_height="wrap_content" />
 
     <Button
         android:id="@+id/saveAvatarButton"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -79,6 +79,7 @@
                 android:layout_width="72dp"
                 android:layout_height="72dp"
                 android:layout_gravity="center"
+                android:contentDescription="@string/profile_avatar_desc"
                 android:src="@drawable/ic_avatar" />
 
             <LinearLayout


### PR DESCRIPTION
## Summary
- add avatar onResume refresh in ProfileFragment
- show avatar preview updates in AvatarCustomizationFragment
- label each avatar picker field in `fragment_avatar_customization`
- set content description on profile avatar image

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850abe518008332bb2b3a2960060394