### PR TITLE
Add onboarding strings

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -88,23 +88,23 @@ public class OnboardingActivity extends AppCompatActivity {
         List<OnboardingItem> items = new ArrayList<>();
         items.add(new OnboardingItem.Builder()
                 .imageResId(R.drawable.brain_train)
-                .title("Train your brain in 60 seconds a day")
-                .description("Quick, fun exercises to keep your mind sharp")
+                .title(getString(R.string.onboarding_slide1_title))
+                .description(getString(R.string.onboarding_slide1_desc))
                 .build());
         items.add(new OnboardingItem.Builder()
                 .imageResId(R.drawable.word_math)
-                .title("Form words. Solve math. Beat the clock!")
-                .description("Challenge yourself with various brain games")
+                .title(getString(R.string.onboarding_slide2_title))
+                .description(getString(R.string.onboarding_slide2_desc))
                 .build());
         items.add(new OnboardingItem.Builder()
                 .imageResId(R.drawable.rewards)
-                .title("Earn streaks, top leaderboards!")
-                .description("Compete and track your progress")
+                .title(getString(R.string.onboarding_slide3_title))
+                .description(getString(R.string.onboarding_slide3_desc))
                 .build());
         items.add(new OnboardingItem.Builder()
                 .imageResId(R.drawable.profile)
-                .title("Sign in to save progress")
-                .description("Or continue as guest to try it out")
+                .title(getString(R.string.onboarding_slide4_title))
+                .description(getString(R.string.onboarding_slide4_desc))
                 .build());
 
         OnboardingAdapter adapter = new OnboardingAdapter(items);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,6 +156,14 @@
     <!-- Accessibility descriptions -->
     <string name="app_icon_desc">Cognify app icon</string>
     <string name="onboarding_image_desc">Onboarding illustration</string>
+    <string name="onboarding_slide1_title">Train your brain in 60 seconds a day</string>
+    <string name="onboarding_slide1_desc">Quick, fun exercises to keep your mind sharp</string>
+    <string name="onboarding_slide2_title">Form words. Solve math. Beat the clock!</string>
+    <string name="onboarding_slide2_desc">Challenge yourself with various brain games</string>
+    <string name="onboarding_slide3_title">Earn streaks, top leaderboards!</string>
+    <string name="onboarding_slide3_desc">Compete and track your progress</string>
+    <string name="onboarding_slide4_title">Sign in to save progress</string>
+    <string name="onboarding_slide4_desc">Or continue as guest to try it out</string>
     <string name="streak_icon_desc">Streak icon</string>
     <string name="profile_avatar_desc">User avatar</string>
 


### PR DESCRIPTION
## Summary
- add onboarding slide titles/descriptions to strings.xml
- use `getString()` to fetch these texts in `OnboardingActivity`

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850ad38a1188332b8aace63b43a233a