### PR TITLE
Improve text contrast on welcome card

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -82,6 +82,16 @@
                 android:layout_height="match_parent"
                 android:background="@drawable/bg_tile_gradient">
 
+                <!-- Semi-transparent scrim for improved text contrast -->
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_alignParentTop="true"
+                    android:layout_alignParentBottom="true"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignParentEnd="true"
+                    android:background="#80000000" />
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"


### PR DESCRIPTION
## Summary
- overlay a semi-transparent scrim on the gradient background so white text stays readable

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850ad4678ac8332989c8f8896780c8f