### PR TITLE
Improve user feedback visibility

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -5,7 +5,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
+import com.google.android.material.snackbar.Snackbar;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -201,9 +201,9 @@ public class OnboardingActivity extends AppCompatActivity {
                 }
             } catch (ApiException e) {
                 ExceptionLogger.log("OnboardingActivity", e);
-                Toast.makeText(this,
-                        "Google sign-in failed: " + e.getMessage(),
-                        Toast.LENGTH_LONG).show();
+                String msg = "Google sign-in failed: " + e.getMessage();
+                Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+                binding.getRoot().announceForAccessibility(msg);
             }
         }
     }
@@ -219,20 +219,21 @@ public class OnboardingActivity extends AppCompatActivity {
                                 gAccount.getDisplayName(),
                                 gAccount.getEmail()
                         ).addOnSuccessListener(v -> launchMainActivity())
-                         .addOnFailureListener(err ->
-                                 Toast.makeText(this,
-                                         "Failed to update profile: " + err.getMessage(),
-                                         Toast.LENGTH_LONG).show());
+                         .addOnFailureListener(err -> {
+                             String msg = "Failed to update profile: " + err.getMessage();
+                             Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+                             binding.getRoot().announceForAccessibility(msg);
+                         });
                     } else {
-                        Toast.makeText(this,
-                                "Authentication succeeded but no user found.",
-                                Toast.LENGTH_LONG).show();
+                        String msg = "Authentication succeeded but no user found.";
+                        Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+                        binding.getRoot().announceForAccessibility(msg);
                     }
                 })
                 .addOnFailureListener(e -> {
-                    Toast.makeText(this,
-                            "Firebase authentication failed: " + e.getMessage(),
-                            Toast.LENGTH_LONG).show();
+                    String msg = "Firebase authentication failed: " + e.getMessage();
+                    Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+                    binding.getRoot().announceForAccessibility(msg);
                 });
     }
 

--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -3,7 +3,8 @@ package com.gigamind.cognify.ui;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.TextView;
-import android.widget.Toast;
+import android.view.View;
+import com.google.android.material.snackbar.Snackbar;
 
 import com.gigamind.cognify.util.GameConfig;
 import com.gigamind.cognify.util.GameTimer;
@@ -37,7 +38,10 @@ public class QuickMathActivity extends AppCompatActivity {
 
         int challengeScore = getIntent().getIntExtra(Constants.EXTRA_CHALLENGE_SCORE, -1);
         if (challengeScore >= 0) {
-            Toast.makeText(this, getString(R.string.challenge_toast, challengeScore), Toast.LENGTH_LONG).show();
+            String msg = getString(R.string.challenge_toast, challengeScore);
+            View rootView = findViewById(android.R.id.content);
+            Snackbar.make(rootView, msg, Snackbar.LENGTH_LONG).show();
+            rootView.announceForAccessibility(msg);
         }
 
         analytics = GameAnalytics.getInstance(this);

--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -24,6 +24,7 @@ import android.os.Handler;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import com.google.android.material.snackbar.Snackbar;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -135,11 +136,10 @@ public class ResultActivity extends AppCompatActivity {
         int oldBadge = com.gigamind.cognify.util.BadgeUtils.badgeIndexForXp(oldTotalXp);
         int newBadge = com.gigamind.cognify.util.BadgeUtils.badgeIndexForXp(newTotalXp);
         if (newBadge > oldBadge) {
-            android.widget.Toast.makeText(
-                    this,
-                    getString(R.string.trophy_room) + ": " + com.gigamind.cognify.util.BadgeUtils.NAMES[newBadge],
-                    android.widget.Toast.LENGTH_LONG
-            ).show();
+            String msg = getString(R.string.trophy_room) + ": " + com.gigamind.cognify.util.BadgeUtils.NAMES[newBadge];
+            View root = findViewById(android.R.id.content);
+            Snackbar.make(root, msg, Snackbar.LENGTH_LONG).show();
+            root.announceForAccessibility(msg);
         }
 
         // (8) Kick off Firestore merge in background

--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -8,7 +8,7 @@ import android.view.HapticFeedbackConstants;
 import android.view.View;
 import android.widget.GridLayout;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.google.android.material.snackbar.Snackbar;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.RecyclerView;
@@ -66,7 +66,10 @@ public class WordDashActivity extends AppCompatActivity {
 
         int challengeScore = getIntent().getIntExtra(Constants.EXTRA_CHALLENGE_SCORE, -1);
         if (challengeScore >= 0) {
-            Toast.makeText(this, getString(R.string.challenge_toast, challengeScore), Toast.LENGTH_LONG).show();
+            String msg = getString(R.string.challenge_toast, challengeScore);
+            View root = findViewById(android.R.id.content);
+            Snackbar.make(root, msg, Snackbar.LENGTH_LONG).show();
+            root.announceForAccessibility(msg);
         }
 
         analytics = GameAnalytics.getInstance(this);
@@ -109,7 +112,10 @@ public class WordDashActivity extends AppCompatActivity {
                             tutorialOverlay.addStep(scoreText, getString(R.string.tutorial_step_score));
                             tutorialOverlay.addStep(timerText, getString(R.string.tutorial_step_timer));
                             tutorialOverlay.setOnComplete(() -> {
-                                Toast.makeText(this, R.string.tutorial_complete, Toast.LENGTH_SHORT).show();
+                                String msg = getString(R.string.tutorial_complete);
+                                View root = findViewById(android.R.id.content);
+                                Snackbar.make(root, msg, Snackbar.LENGTH_SHORT).show();
+                                root.announceForAccessibility(msg);
                                 tutorialHelper.markTutorialCompleted();
                                 tutorialActive = false;
                                 startGame();
@@ -120,7 +126,9 @@ public class WordDashActivity extends AppCompatActivity {
                         }
                     } else {
                         // Handle dictionary load error
-                        Toast.makeText(this, "Error loading game dictionary", Toast.LENGTH_LONG).show();
+                        String msg = "Error loading game dictionary";
+                        Snackbar.make(findViewById(android.R.id.content), msg, Snackbar.LENGTH_LONG).show();
+                        findViewById(android.R.id.content).announceForAccessibility(msg);
                         finish();
                     }
                 }
@@ -263,7 +271,10 @@ public class WordDashActivity extends AppCompatActivity {
             foundWordsList.add(word);
             foundWordsAdapter.submitList(new ArrayList<>(foundWordsList));
             if (tutorialActive) {
-                Toast.makeText(this, R.string.tutorial_complete, Toast.LENGTH_SHORT).show();
+                String msg = getString(R.string.tutorial_complete);
+                View root = findViewById(android.R.id.content);
+                Snackbar.make(root, msg, Snackbar.LENGTH_SHORT).show();
+                root.announceForAccessibility(msg);
                 tutorialHelper.markTutorialCompleted();
                 tutorialActive = false;
             }
@@ -309,7 +320,9 @@ public class WordDashActivity extends AppCompatActivity {
     }
 
     private void showError(String message) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+        View root = findViewById(android.R.id.content);
+        Snackbar.make(root, message, Snackbar.LENGTH_SHORT).show();
+        root.announceForAccessibility(message);
         letterGrid.performHapticFeedback(HapticFeedbackConstants.REJECT);
     }
 

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -11,7 +11,6 @@ import android.view.ViewGroup;
 import android.view.animation.AnimationUtils;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -11,7 +11,6 @@ import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -8,7 +8,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
+import com.google.android.material.snackbar.Snackbar;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -176,16 +176,22 @@ public class SettingsFragment extends Fragment {
         user.reauthenticate(credential)
                 .addOnSuccessListener(aVoid -> FirebaseService.getInstance().deleteAccountAndData()
                         .addOnSuccessListener(v -> {
-                            Toast.makeText(requireContext(), R.string.sign_out, Toast.LENGTH_SHORT).show();
+                            String msg = getString(R.string.sign_out);
+                            Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_SHORT).show();
+                            binding.getRoot().announceForAccessibility(msg);
                             startActivity(new Intent(requireActivity(), OnboardingActivity.class)
                                     .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK));
                         })
-                        .addOnFailureListener(e -> Toast.makeText(requireContext(),
-                                getString(R.string.delete_account_error, e.getMessage()),
-                                Toast.LENGTH_LONG).show()))
-                .addOnFailureListener(e -> Toast.makeText(requireContext(),
-                        getString(R.string.delete_account_error, e.getMessage()),
-                        Toast.LENGTH_LONG).show());
+                        .addOnFailureListener(e -> {
+                            String msg = getString(R.string.delete_account_error, e.getMessage());
+                            Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+                            binding.getRoot().announceForAccessibility(msg);
+                        }))
+                .addOnFailureListener(e -> {
+                    String msg = getString(R.string.delete_account_error, e.getMessage());
+                    Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+                    binding.getRoot().announceForAccessibility(msg);
+                });
     }
 
     @Override
@@ -199,9 +205,9 @@ public class SettingsFragment extends Fragment {
                     reauthenticateAndDelete(account.getIdToken());
                 }
             } catch (ApiException e) {
-                Toast.makeText(requireContext(),
-                        getString(R.string.delete_account_error, e.getMessage()),
-                        Toast.LENGTH_LONG).show();
+                String msg = getString(R.string.delete_account_error, e.getMessage());
+                Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+                binding.getRoot().announceForAccessibility(msg);
             }
         }
     }

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -11,7 +11,7 @@ import android.view.ViewGroup;
 import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
+import com.google.android.material.snackbar.Snackbar;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -121,7 +121,9 @@ public class WordDashFragment extends Fragment {
         View.OnClickListener animatedClickListener = v -> {
             v.startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.button_bounce));
             if (!tutorialHelper.isTutorialCompleted()) {
-                Toast.makeText(requireContext(), R.string.play_tip, Toast.LENGTH_SHORT).show();
+                String msg = getString(R.string.play_tip);
+                Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_SHORT).show();
+                binding.getRoot().announceForAccessibility(msg);
             }
             handleGameLaunch(v);
         };

--- a/app/src/main/java/com/gigamind/cognify/util/NotificationPermissionHelper.java
+++ b/app/src/main/java/com/gigamind/cognify/util/NotificationPermissionHelper.java
@@ -5,7 +5,8 @@ import android.app.Activity;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.widget.Toast;
+import android.view.View;
+import com.google.android.material.snackbar.Snackbar;
 
 import androidx.activity.ComponentActivity;
 import androidx.activity.result.ActivityResultLauncher;
@@ -43,16 +44,18 @@ public class NotificationPermissionHelper {
                 new ActivityResultContracts.RequestPermission(),
                 isGranted -> {
                     if (isGranted) {
-                        Toast.makeText(activity,
-                                "Notifications enabled. You won't lose your streak!",
-                                Toast.LENGTH_SHORT).show();
+                        String msg = "Notifications enabled. You won't lose your streak!";
+                        View root = activity.findViewById(android.R.id.content);
+                        Snackbar.make(root, msg, Snackbar.LENGTH_SHORT).show();
+                        root.announceForAccessibility(msg);
                     } else {
                         prefs.edit()
                                 .putBoolean(Constants.PREF_ASKED_NOTIFICATIONS, true)
                                 .apply();
-                        Toast.makeText(activity,
-                                "Notifications disabled. You may lose your streak if you don't play.",
-                                Toast.LENGTH_SHORT).show();
+                        String msg = "Notifications disabled. You may lose your streak if you don't play.";
+                        View root = activity.findViewById(android.R.id.content);
+                        Snackbar.make(root, msg, Snackbar.LENGTH_SHORT).show();
+                        root.announceForAccessibility(msg);
                     }
                     callback.onPermissionResult(isGranted);
                 }


### PR DESCRIPTION
## Summary
- swap key Toasts for Snackbars in several activities and helpers
- announce Snackbar messages for screen readers

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850ad428f8c8332b350533827771aaa