### PR TITLE
Enhance avatar customization

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/profile/AvatarCustomizationFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/AvatarCustomizationFragment.java
@@ -101,19 +101,19 @@ public class AvatarCustomizationFragment extends Fragment {
 
         ArrayAdapter<String> hairAdapter = new ArrayAdapter<>(requireContext(),
                 R.layout.spinner_item_white,
-                new String[]{"Style 1", "Style 2", "Style 3", "Style 4"});
+                new String[]{"Style 1", "Style 2", "Style 3", "Style 4", "Style 5", "Style 6"});
         hairAdapter.setDropDownViewResource(R.layout.spinner_dropdown_item_white);
         hairSpinner.setAdapter(hairAdapter);
 
         ArrayAdapter<String> eyesAdapter = new ArrayAdapter<>(requireContext(),
                 R.layout.spinner_item_white,
-                new String[]{"Eyes 1", "Eyes 2", "Eyes 3", "Eyes 4"});
+                new String[]{"Eyes 1", "Eyes 2", "Eyes 3", "Eyes 4", "Eyes 5", "Eyes 6"});
         eyesAdapter.setDropDownViewResource(R.layout.spinner_dropdown_item_white);
         eyesSpinner.setAdapter(eyesAdapter);
 
         ArrayAdapter<String> mouthAdapter = new ArrayAdapter<>(requireContext(),
                 R.layout.spinner_item_white,
-                new String[]{"Mouth 1", "Mouth 2", "Mouth 3", "Mouth 4"});
+                new String[]{"Mouth 1", "Mouth 2", "Mouth 3", "Mouth 4", "Mouth 5", "Mouth 6"});
         mouthAdapter.setDropDownViewResource(R.layout.spinner_dropdown_item_white);
         mouthSpinner.setAdapter(mouthAdapter);
     }
@@ -163,6 +163,12 @@ public class AvatarCustomizationFragment extends Fragment {
             case 3:
                 hairView.setImageResource(R.drawable.avatar_hair_4);
                 break;
+            case 4:
+                hairView.setImageResource(R.drawable.avatar_hair_5);
+                break;
+            case 5:
+                hairView.setImageResource(R.drawable.avatar_hair_6);
+                break;
         }
 
         switch (eyesSpinner.getSelectedItemPosition()) {
@@ -178,6 +184,12 @@ public class AvatarCustomizationFragment extends Fragment {
             case 3:
                 eyesView.setImageResource(R.drawable.avatar_eyes_4);
                 break;
+            case 4:
+                eyesView.setImageResource(R.drawable.avatar_eyes_5);
+                break;
+            case 5:
+                eyesView.setImageResource(R.drawable.avatar_eyes_6);
+                break;
         }
 
         switch (mouthSpinner.getSelectedItemPosition()) {
@@ -192,6 +204,12 @@ public class AvatarCustomizationFragment extends Fragment {
                 break;
             case 3:
                 mouthView.setImageResource(R.drawable.avatar_mouth_4);
+                break;
+            case 4:
+                mouthView.setImageResource(R.drawable.avatar_mouth_5);
+                break;
+            case 5:
+                mouthView.setImageResource(R.drawable.avatar_mouth_6);
                 break;
         }
     }

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -254,6 +254,12 @@ public class ProfileFragment extends Fragment {
             case 3:
                 avatarHair.setImageResource(R.drawable.avatar_hair_4);
                 break;
+            case 4:
+                avatarHair.setImageResource(R.drawable.avatar_hair_5);
+                break;
+            case 5:
+                avatarHair.setImageResource(R.drawable.avatar_hair_6);
+                break;
         }
 
         switch (eyes) {
@@ -269,6 +275,12 @@ public class ProfileFragment extends Fragment {
             case 3:
                 avatarEyes.setImageResource(R.drawable.avatar_eyes_4);
                 break;
+            case 4:
+                avatarEyes.setImageResource(R.drawable.avatar_eyes_5);
+                break;
+            case 5:
+                avatarEyes.setImageResource(R.drawable.avatar_eyes_6);
+                break;
         }
 
         switch (mouth) {
@@ -283,6 +295,12 @@ public class ProfileFragment extends Fragment {
                 break;
             case 3:
                 avatarMouth.setImageResource(R.drawable.avatar_mouth_4);
+                break;
+            case 4:
+                avatarMouth.setImageResource(R.drawable.avatar_mouth_5);
+                break;
+            case 5:
+                avatarMouth.setImageResource(R.drawable.avatar_mouth_6);
                 break;
         }
     }

--- a/app/src/main/res/drawable/avatar_eyes_5.xml
+++ b/app/src/main/res/drawable/avatar_eyes_5.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#000000" android:pathData="M30,52 a4,4 0 1 0 0.1,0"/>
+    <path android:fillColor="#000000" android:pathData="M70,52 a4,4 0 1 0 0.1,0"/>
+</vector>

--- a/app/src/main/res/drawable/avatar_eyes_6.xml
+++ b/app/src/main/res/drawable/avatar_eyes_6.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#000000" android:pathData="M30,50 a5,6 0 1 0 0.1,0"/>
+    <path android:fillColor="#000000" android:pathData="M70,50 a5,6 0 1 0 0.1,0"/>
+</vector>

--- a/app/src/main/res/drawable/avatar_hair_5.xml
+++ b/app/src/main/res/drawable/avatar_hair_5.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M15,35 C30,10 70,10 85,35 L90,0 L10,0 Z" />
+</vector>

--- a/app/src/main/res/drawable/avatar_hair_6.xml
+++ b/app/src/main/res/drawable/avatar_hair_6.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M10,25 C25,15 75,15 90,25 L90,0 L10,0 Z" />
+</vector>

--- a/app/src/main/res/drawable/avatar_mouth_5.xml
+++ b/app/src/main/res/drawable/avatar_mouth_5.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#000000" android:pathData="M30,70 Q50,85 70,70" />
+</vector>

--- a/app/src/main/res/drawable/avatar_mouth_6.xml
+++ b/app/src/main/res/drawable/avatar_mouth_6.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#000000" android:pathData="M30,74 Q50,65 70,74" />
+</vector>

--- a/app/src/main/res/layout/spinner_dropdown_item_white.xml
+++ b/app/src/main/res/layout/spinner_dropdown_item_white.xml
@@ -2,5 +2,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="8dp"
-    android:textColor="@color/white"
+    android:textColor="@color/black"
+    android:background="@color/white"
     android:textSize="16sp" />

--- a/app/src/main/res/layout/spinner_item_white.xml
+++ b/app/src/main/res/layout/spinner_item_white.xml
@@ -2,5 +2,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="8dp"
-    android:textColor="@color/white"
+    android:textColor="@color/black"
+    android:background="@color/white"
     android:textSize="16sp" />


### PR DESCRIPTION
## Summary
- extend avatar options for hair, eyes and mouth
- show white background with black text in avatar spinners
- add vector drawables for new avatar pieces

## Testing
- `./gradlew test` *(fails: HTTP 403 when downloading gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6850b1fd979083328adad313718abfd9