### PR TITLE
Add avatar body and accessory customization

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/profile/AvatarCustomizationFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/AvatarCustomizationFragment.java
@@ -30,22 +30,42 @@ public class AvatarCustomizationFragment extends Fragment {
     private ImageView hairView;
     private ImageView eyesView;
     private ImageView mouthView;
+    private ImageView bodyView;
+    private ImageView noseView;
+    private ImageView earsView;
+    private ImageView facialHairView;
+    private ImageView accessoryView;
 
     private RecyclerView skinRecycler;
     private RecyclerView hairRecycler;
     private RecyclerView eyesRecycler;
     private RecyclerView mouthRecycler;
+    private RecyclerView bodyRecycler;
+    private RecyclerView noseRecycler;
+    private RecyclerView earsRecycler;
+    private RecyclerView facialHairRecycler;
+    private RecyclerView accessoryRecycler;
 
     private AvatarOptionAdapter skinAdapter;
     private AvatarOptionAdapter hairAdapter;
     private AvatarOptionAdapter eyesAdapter;
     private AvatarOptionAdapter mouthAdapter;
+    private AvatarOptionAdapter bodyAdapter;
+    private AvatarOptionAdapter noseAdapter;
+    private AvatarOptionAdapter earsAdapter;
+    private AvatarOptionAdapter facialHairAdapter;
+    private AvatarOptionAdapter accessoryAdapter;
     private SharedPreferences prefs;
 
     private static final String KEY_SKIN = Constants.AVATAR_SKIN;
     private static final String KEY_HAIR = Constants.AVATAR_HAIR;
     private static final String KEY_EYES = Constants.AVATAR_EYES;
     private static final String KEY_MOUTH = Constants.AVATAR_MOUTH;
+    private static final String KEY_BODY = Constants.AVATAR_BODY;
+    private static final String KEY_NOSE = Constants.AVATAR_NOSE;
+    private static final String KEY_EARS = Constants.AVATAR_EARS;
+    private static final String KEY_FACIAL_HAIR = Constants.AVATAR_FACIAL_HAIR;
+    private static final String KEY_ACCESSORY = Constants.AVATAR_ACCESSORY;
 
     @Nullable
     @Override
@@ -63,11 +83,21 @@ public class AvatarCustomizationFragment extends Fragment {
         hairView = view.findViewById(R.id.hairView);
         eyesView = view.findViewById(R.id.eyesView);
         mouthView = view.findViewById(R.id.mouthView);
+        bodyView = view.findViewById(R.id.bodyView);
+        noseView = view.findViewById(R.id.noseView);
+        earsView = view.findViewById(R.id.earsView);
+        facialHairView = view.findViewById(R.id.facialHairView);
+        accessoryView = view.findViewById(R.id.accessoryView);
 
         skinRecycler = view.findViewById(R.id.skinRecycler);
         hairRecycler = view.findViewById(R.id.hairRecycler);
         eyesRecycler = view.findViewById(R.id.eyesRecycler);
         mouthRecycler = view.findViewById(R.id.mouthRecycler);
+        bodyRecycler = view.findViewById(R.id.bodyRecycler);
+        noseRecycler = view.findViewById(R.id.noseRecycler);
+        earsRecycler = view.findViewById(R.id.earsRecycler);
+        facialHairRecycler = view.findViewById(R.id.facialHairRecycler);
+        accessoryRecycler = view.findViewById(R.id.accessoryRecycler);
         Button saveButton = view.findViewById(R.id.saveAvatarButton);
 
         setupRecyclers();
@@ -79,6 +109,11 @@ public class AvatarCustomizationFragment extends Fragment {
                     .putInt(KEY_HAIR, hairAdapter.getSelectedIndex())
                     .putInt(KEY_EYES, eyesAdapter.getSelectedIndex())
                     .putInt(KEY_MOUTH, mouthAdapter.getSelectedIndex())
+                    .putInt(KEY_BODY, bodyAdapter.getSelectedIndex())
+                    .putInt(KEY_NOSE, noseAdapter.getSelectedIndex())
+                    .putInt(KEY_EARS, earsAdapter.getSelectedIndex())
+                    .putInt(KEY_FACIAL_HAIR, facialHairAdapter.getSelectedIndex())
+                    .putInt(KEY_ACCESSORY, accessoryAdapter.getSelectedIndex())
                     .apply();
             requireActivity().onBackPressed();
         });
@@ -131,6 +166,51 @@ public class AvatarCustomizationFragment extends Fragment {
         mouthAdapter = new AvatarOptionAdapter(mouthOptions, pos -> updatePreview());
         mouthRecycler.setLayoutManager(new LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false));
         mouthRecycler.setAdapter(mouthAdapter);
+
+        int[] bodyOptions = {
+                R.drawable.avatar_body_1,
+                R.drawable.avatar_body_2,
+                R.drawable.avatar_body_3
+        };
+        bodyAdapter = new AvatarOptionAdapter(bodyOptions, pos -> updatePreview());
+        bodyRecycler.setLayoutManager(new LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false));
+        bodyRecycler.setAdapter(bodyAdapter);
+
+        int[] noseOptions = {
+                R.drawable.avatar_nose_1,
+                R.drawable.avatar_nose_2,
+                R.drawable.avatar_nose_3
+        };
+        noseAdapter = new AvatarOptionAdapter(noseOptions, pos -> updatePreview());
+        noseRecycler.setLayoutManager(new LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false));
+        noseRecycler.setAdapter(noseAdapter);
+
+        int[] earsOptions = {
+                R.drawable.avatar_ears_1,
+                R.drawable.avatar_ears_2,
+                R.drawable.avatar_ears_3
+        };
+        earsAdapter = new AvatarOptionAdapter(earsOptions, pos -> updatePreview());
+        earsRecycler.setLayoutManager(new LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false));
+        earsRecycler.setAdapter(earsAdapter);
+
+        int[] facialHairOptions = {
+                R.drawable.avatar_facial_hair_1,
+                R.drawable.avatar_facial_hair_2,
+                R.drawable.avatar_facial_hair_3
+        };
+        facialHairAdapter = new AvatarOptionAdapter(facialHairOptions, pos -> updatePreview());
+        facialHairRecycler.setLayoutManager(new LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false));
+        facialHairRecycler.setAdapter(facialHairAdapter);
+
+        int[] accessoryOptions = {
+                R.drawable.avatar_accessory_1,
+                R.drawable.avatar_accessory_2,
+                R.drawable.avatar_accessory_3
+        };
+        accessoryAdapter = new AvatarOptionAdapter(accessoryOptions, pos -> updatePreview());
+        accessoryRecycler.setLayoutManager(new LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false));
+        accessoryRecycler.setAdapter(accessoryAdapter);
     }
 
     private void loadSelections() {
@@ -138,11 +218,21 @@ public class AvatarCustomizationFragment extends Fragment {
         int hair = prefs.getInt(KEY_HAIR, 0);
         int eyes = prefs.getInt(KEY_EYES, 0);
         int mouth = prefs.getInt(KEY_MOUTH, 0);
+        int body = prefs.getInt(KEY_BODY, 0);
+        int nose = prefs.getInt(KEY_NOSE, 0);
+        int ears = prefs.getInt(KEY_EARS, 0);
+        int facial = prefs.getInt(KEY_FACIAL_HAIR, 0);
+        int accessory = prefs.getInt(KEY_ACCESSORY, 0);
 
         skinAdapter.setSelectedIndex(skin);
         hairAdapter.setSelectedIndex(hair);
         eyesAdapter.setSelectedIndex(eyes);
         mouthAdapter.setSelectedIndex(mouth);
+        bodyAdapter.setSelectedIndex(body);
+        noseAdapter.setSelectedIndex(nose);
+        earsAdapter.setSelectedIndex(ears);
+        facialHairAdapter.setSelectedIndex(facial);
+        accessoryAdapter.setSelectedIndex(accessory);
         updatePreview();
     }
 
@@ -229,6 +319,71 @@ public class AvatarCustomizationFragment extends Fragment {
                 break;
             case 5:
                 mouthView.setImageResource(R.drawable.avatar_mouth_6);
+                break;
+        }
+
+        int bodyPos = bodyAdapter != null ? bodyAdapter.getSelectedIndex() : 0;
+        switch (bodyPos) {
+            case 0:
+                bodyView.setImageResource(R.drawable.avatar_body_1);
+                break;
+            case 1:
+                bodyView.setImageResource(R.drawable.avatar_body_2);
+                break;
+            case 2:
+                bodyView.setImageResource(R.drawable.avatar_body_3);
+                break;
+        }
+
+        int nosePos = noseAdapter != null ? noseAdapter.getSelectedIndex() : 0;
+        switch (nosePos) {
+            case 0:
+                noseView.setImageResource(R.drawable.avatar_nose_1);
+                break;
+            case 1:
+                noseView.setImageResource(R.drawable.avatar_nose_2);
+                break;
+            case 2:
+                noseView.setImageResource(R.drawable.avatar_nose_3);
+                break;
+        }
+
+        int earsPos = earsAdapter != null ? earsAdapter.getSelectedIndex() : 0;
+        switch (earsPos) {
+            case 0:
+                earsView.setImageResource(R.drawable.avatar_ears_1);
+                break;
+            case 1:
+                earsView.setImageResource(R.drawable.avatar_ears_2);
+                break;
+            case 2:
+                earsView.setImageResource(R.drawable.avatar_ears_3);
+                break;
+        }
+
+        int facialPos = facialHairAdapter != null ? facialHairAdapter.getSelectedIndex() : 0;
+        switch (facialPos) {
+            case 0:
+                facialHairView.setImageResource(R.drawable.avatar_facial_hair_1);
+                break;
+            case 1:
+                facialHairView.setImageResource(R.drawable.avatar_facial_hair_2);
+                break;
+            case 2:
+                facialHairView.setImageResource(R.drawable.avatar_facial_hair_3);
+                break;
+        }
+
+        int accessoryPos = accessoryAdapter != null ? accessoryAdapter.getSelectedIndex() : 0;
+        switch (accessoryPos) {
+            case 0:
+                accessoryView.setImageResource(R.drawable.avatar_accessory_1);
+                break;
+            case 1:
+                accessoryView.setImageResource(R.drawable.avatar_accessory_2);
+                break;
+            case 2:
+                accessoryView.setImageResource(R.drawable.avatar_accessory_3);
                 break;
         }
     }

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -44,6 +44,11 @@ public class ProfileFragment extends Fragment {
     private ImageView avatarHair;
     private ImageView avatarEyes;
     private ImageView avatarMouth;
+    private ImageView avatarBody;
+    private ImageView avatarNose;
+    private ImageView avatarEars;
+    private ImageView avatarFacialHair;
+    private ImageView avatarAccessory;
     private TextView streakValueText;
     private TextView xpValueText;
     private TextView gamesPlayedValue;
@@ -80,6 +85,11 @@ public class ProfileFragment extends Fragment {
         avatarHair          = view.findViewById(R.id.avatarHair);
         avatarEyes          = view.findViewById(R.id.avatarEyes);
         avatarMouth         = view.findViewById(R.id.avatarMouth);
+        avatarBody          = view.findViewById(R.id.avatarBody);
+        avatarNose          = view.findViewById(R.id.avatarNose);
+        avatarEars          = view.findViewById(R.id.avatarEars);
+        avatarFacialHair    = view.findViewById(R.id.avatarFacialHair);
+        avatarAccessory     = view.findViewById(R.id.avatarAccessory);
         streakValueText     = view.findViewById(R.id.streakValue);
         xpValueText         = view.findViewById(R.id.xpValue);
         gamesPlayedValue    = view.findViewById(R.id.gamesPlayedValue);
@@ -222,6 +232,11 @@ public class ProfileFragment extends Fragment {
         int hair = prefs.getInt(Constants.AVATAR_HAIR, 0);
         int eyes = prefs.getInt(Constants.AVATAR_EYES, 0);
         int mouth = prefs.getInt(Constants.AVATAR_MOUTH, 0);
+        int body = prefs.getInt(Constants.AVATAR_BODY, 0);
+        int nose = prefs.getInt(Constants.AVATAR_NOSE, 0);
+        int ears = prefs.getInt(Constants.AVATAR_EARS, 0);
+        int facial = prefs.getInt(Constants.AVATAR_FACIAL_HAIR, 0);
+        int accessory = prefs.getInt(Constants.AVATAR_ACCESSORY, 0);
 
         switch (skin) {
             case 0:
@@ -301,6 +316,66 @@ public class ProfileFragment extends Fragment {
                 break;
             case 5:
                 avatarMouth.setImageResource(R.drawable.avatar_mouth_6);
+                break;
+        }
+
+        switch (body) {
+            case 0:
+                avatarBody.setImageResource(R.drawable.avatar_body_1);
+                break;
+            case 1:
+                avatarBody.setImageResource(R.drawable.avatar_body_2);
+                break;
+            case 2:
+                avatarBody.setImageResource(R.drawable.avatar_body_3);
+                break;
+        }
+
+        switch (nose) {
+            case 0:
+                avatarNose.setImageResource(R.drawable.avatar_nose_1);
+                break;
+            case 1:
+                avatarNose.setImageResource(R.drawable.avatar_nose_2);
+                break;
+            case 2:
+                avatarNose.setImageResource(R.drawable.avatar_nose_3);
+                break;
+        }
+
+        switch (ears) {
+            case 0:
+                avatarEars.setImageResource(R.drawable.avatar_ears_1);
+                break;
+            case 1:
+                avatarEars.setImageResource(R.drawable.avatar_ears_2);
+                break;
+            case 2:
+                avatarEars.setImageResource(R.drawable.avatar_ears_3);
+                break;
+        }
+
+        switch (facial) {
+            case 0:
+                avatarFacialHair.setImageResource(R.drawable.avatar_facial_hair_1);
+                break;
+            case 1:
+                avatarFacialHair.setImageResource(R.drawable.avatar_facial_hair_2);
+                break;
+            case 2:
+                avatarFacialHair.setImageResource(R.drawable.avatar_facial_hair_3);
+                break;
+        }
+
+        switch (accessory) {
+            case 0:
+                avatarAccessory.setImageResource(R.drawable.avatar_accessory_1);
+                break;
+            case 1:
+                avatarAccessory.setImageResource(R.drawable.avatar_accessory_2);
+                break;
+            case 2:
+                avatarAccessory.setImageResource(R.drawable.avatar_accessory_3);
                 break;
         }
     }

--- a/app/src/main/java/com/gigamind/cognify/util/Constants.java
+++ b/app/src/main/java/com/gigamind/cognify/util/Constants.java
@@ -46,4 +46,9 @@ public class Constants {
     public static final String AVATAR_HAIR = "avatar_hair";
     public static final String AVATAR_EYES = "avatar_eyes";
     public static final String AVATAR_MOUTH = "avatar_mouth";
+    public static final String AVATAR_BODY = "avatar_body";
+    public static final String AVATAR_NOSE = "avatar_nose";
+    public static final String AVATAR_EARS = "avatar_ears";
+    public static final String AVATAR_FACIAL_HAIR = "avatar_facial_hair";
+    public static final String AVATAR_ACCESSORY = "avatar_accessory";
 }

--- a/app/src/main/res/drawable/avatar_accessory_1.xml
+++ b/app/src/main/res/drawable/avatar_accessory_1.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#9E9E9E" android:pathData="M20,20 L80,20 70,30 30,30 Z" />
+</vector>

--- a/app/src/main/res/drawable/avatar_accessory_2.xml
+++ b/app/src/main/res/drawable/avatar_accessory_2.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#FFEB3B" android:pathData="M45,75 a5,5 0 1 0 10,0 a5,5 0 1 0 -10,0" />
+</vector>

--- a/app/src/main/res/drawable/avatar_accessory_3.xml
+++ b/app/src/main/res/drawable/avatar_accessory_3.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#E91E63" android:pathData="M10,50 a5,5 0 1 0 10,0" />
+    <path android:fillColor="#E91E63" android:pathData="M90,50 a5,5 0 1 0 10,0" />
+</vector>

--- a/app/src/main/res/drawable/avatar_body_1.xml
+++ b/app/src/main/res/drawable/avatar_body_1.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#2196F3" android:pathData="M20,50 h60 v40 h-60z" />
+</vector>

--- a/app/src/main/res/drawable/avatar_body_2.xml
+++ b/app/src/main/res/drawable/avatar_body_2.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#4CAF50" android:pathData="M20,50 h60 v40 h-60z" />
+</vector>

--- a/app/src/main/res/drawable/avatar_body_3.xml
+++ b/app/src/main/res/drawable/avatar_body_3.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#F44336" android:pathData="M20,50 h60 v40 h-60z" />
+</vector>

--- a/app/src/main/res/drawable/avatar_ears_1.xml
+++ b/app/src/main/res/drawable/avatar_ears_1.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#FFC107" android:pathData="M20,40 a5,8 0 1 0 0.1,0"/>
+    <path android:fillColor="#FFC107" android:pathData="M80,40 a5,8 0 1 0 0.1,0"/>
+</vector>

--- a/app/src/main/res/drawable/avatar_ears_2.xml
+++ b/app/src/main/res/drawable/avatar_ears_2.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#FFB300" android:pathData="M18,40 a7,10 0 1 0 0.1,0"/>
+    <path android:fillColor="#FFB300" android:pathData="M82,40 a7,10 0 1 0 0.1,0"/>
+</vector>

--- a/app/src/main/res/drawable/avatar_ears_3.xml
+++ b/app/src/main/res/drawable/avatar_ears_3.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#FFA000" android:pathData="M16,40 a9,12 0 1 0 0.1,0"/>
+    <path android:fillColor="#FFA000" android:pathData="M84,40 a9,12 0 1 0 0.1,0"/>
+</vector>

--- a/app/src/main/res/drawable/avatar_facial_hair_1.xml
+++ b/app/src/main/res/drawable/avatar_facial_hair_1.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#795548" android:pathData="M30,70 Q50,80 70,70" />
+</vector>

--- a/app/src/main/res/drawable/avatar_facial_hair_2.xml
+++ b/app/src/main/res/drawable/avatar_facial_hair_2.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#6D4C41" android:pathData="M35,65 L50,75 65,65" />
+</vector>

--- a/app/src/main/res/drawable/avatar_facial_hair_3.xml
+++ b/app/src/main/res/drawable/avatar_facial_hair_3.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#5D4037" android:pathData="M30,70 Q50,90 70,70 L70,80 L30,80 Z" />
+</vector>

--- a/app/src/main/res/drawable/avatar_nose_1.xml
+++ b/app/src/main/res/drawable/avatar_nose_1.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#000000" android:pathData="M50,40 v20"/>
+</vector>

--- a/app/src/main/res/drawable/avatar_nose_2.xml
+++ b/app/src/main/res/drawable/avatar_nose_2.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#000000" android:pathData="M48,40 L52,50 48,60"/>
+</vector>

--- a/app/src/main/res/drawable/avatar_nose_3.xml
+++ b/app/src/main/res/drawable/avatar_nose_3.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path android:fillColor="#000000" android:pathData="M50,40 Q55,50 50,60"/>
+</vector>

--- a/app/src/main/res/layout/fragment_avatar_customization.xml
+++ b/app/src/main/res/layout/fragment_avatar_customization.xml
@@ -15,6 +15,12 @@
             android:layout_gravity="center_horizontal">
 
             <ImageView
+                android:id="@+id/bodyView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/avatar_body_1" />
+
+            <ImageView
                 android:id="@+id/faceView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -37,6 +43,30 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:src="@drawable/avatar_mouth_1" />
+
+            <ImageView
+                android:id="@+id/noseView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/avatar_nose_1" />
+
+            <ImageView
+                android:id="@+id/earsView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/avatar_ears_1" />
+
+            <ImageView
+                android:id="@+id/facialHairView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/avatar_facial_hair_1" />
+
+            <ImageView
+                android:id="@+id/accessoryView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/avatar_accessory_1" />
         </FrameLayout>
 
         <TextView
@@ -44,6 +74,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:text="@string/skin_color"
+            android:textColor="@color/text_primary"
             android:textStyle="bold" />
 
         <androidx.recyclerview.widget.RecyclerView
@@ -59,6 +90,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:text="@string/hair_style"
+            android:textColor="@color/text_primary"
             android:textStyle="bold" />
 
         <androidx.recyclerview.widget.RecyclerView
@@ -74,6 +106,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:text="@string/eyes_style"
+            android:textColor="@color/text_primary"
             android:textStyle="bold" />
 
         <androidx.recyclerview.widget.RecyclerView
@@ -89,10 +122,91 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:text="@string/mouth_style"
+            android:textColor="@color/text_primary"
             android:textStyle="bold" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/mouthRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:overScrollMode="never"
+            android:scrollbars="none" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/body_style"
+            android:textColor="@color/text_primary"
+            android:textStyle="bold" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/bodyRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:overScrollMode="never"
+            android:scrollbars="none" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/nose_style"
+            android:textColor="@color/text_primary"
+            android:textStyle="bold" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/noseRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:overScrollMode="never"
+            android:scrollbars="none" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/ears_style"
+            android:textColor="@color/text_primary"
+            android:textStyle="bold" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/earsRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:overScrollMode="never"
+            android:scrollbars="none" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/facial_hair_style"
+            android:textColor="@color/text_primary"
+            android:textStyle="bold" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/facialHairRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:overScrollMode="never"
+            android:scrollbars="none" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/accessory_style"
+            android:textColor="@color/text_primary"
+            android:textStyle="bold" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/accessoryRecycler"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -103,6 +103,36 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:src="@drawable/avatar_mouth_1" />
+
+                <ImageView
+                    android:id="@+id/avatarBody"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/avatar_body_1" />
+
+                <ImageView
+                    android:id="@+id/avatarNose"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/avatar_nose_1" />
+
+                <ImageView
+                    android:id="@+id/avatarEars"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/avatar_ears_1" />
+
+                <ImageView
+                    android:id="@+id/avatarFacialHair"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/avatar_facial_hair_1" />
+
+                <ImageView
+                    android:id="@+id/avatarAccessory"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/avatar_accessory_1" />
             </FrameLayout>
 
             <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,6 +178,11 @@
     <string name="hair_style">Hair Style</string>
     <string name="eyes_style">Eyes Style</string>
     <string name="mouth_style">Mouth Style</string>
+    <string name="body_style">Clothing</string>
+    <string name="nose_style">Nose</string>
+    <string name="ears_style">Ears</string>
+    <string name="facial_hair_style">Facial Hair</string>
+    <string name="accessory_style">Accessory</string>
     <string name="avatar_option_desc">Avatar option</string>
     <string name="win_rate">Win Rate</string>
     <!-- Trophy Room -->


### PR DESCRIPTION
## Summary
- extend avatar customization with body, nose, ear, facial hair and accessory options
- keep chosen styles in shared prefs and display on profile
- add placeholder drawable assets for new options
- fix avatar customization labels to use visible text color

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850b5c0ae148332ba83af89571af29c