### PR TITLE
Add face shape customization

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/profile/AvatarCustomizationFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/AvatarCustomizationFragment.java
@@ -36,6 +36,7 @@ public class AvatarCustomizationFragment extends Fragment {
     private ImageView facialHairView;
     private ImageView accessoryView;
 
+    private RecyclerView faceShapeRecycler;
     private RecyclerView skinRecycler;
     private RecyclerView hairRecycler;
     private RecyclerView eyesRecycler;
@@ -55,6 +56,7 @@ public class AvatarCustomizationFragment extends Fragment {
     private AvatarOptionAdapter earsAdapter;
     private AvatarOptionAdapter facialHairAdapter;
     private AvatarOptionAdapter accessoryAdapter;
+    private AvatarOptionAdapter faceShapeAdapter;
     private SharedPreferences prefs;
 
     private static final String KEY_SKIN = Constants.AVATAR_SKIN;
@@ -66,6 +68,7 @@ public class AvatarCustomizationFragment extends Fragment {
     private static final String KEY_EARS = Constants.AVATAR_EARS;
     private static final String KEY_FACIAL_HAIR = Constants.AVATAR_FACIAL_HAIR;
     private static final String KEY_ACCESSORY = Constants.AVATAR_ACCESSORY;
+    private static final String KEY_FACE_SHAPE = Constants.AVATAR_FACE_SHAPE;
 
     @Nullable
     @Override
@@ -88,6 +91,7 @@ public class AvatarCustomizationFragment extends Fragment {
         earsView = view.findViewById(R.id.earsView);
         facialHairView = view.findViewById(R.id.facialHairView);
         accessoryView = view.findViewById(R.id.accessoryView);
+        faceShapeRecycler = view.findViewById(R.id.faceShapeRecycler);
 
         skinRecycler = view.findViewById(R.id.skinRecycler);
         hairRecycler = view.findViewById(R.id.hairRecycler);
@@ -114,6 +118,7 @@ public class AvatarCustomizationFragment extends Fragment {
                     .putInt(KEY_EARS, earsAdapter.getSelectedIndex())
                     .putInt(KEY_FACIAL_HAIR, facialHairAdapter.getSelectedIndex())
                     .putInt(KEY_ACCESSORY, accessoryAdapter.getSelectedIndex())
+                    .putInt(KEY_FACE_SHAPE, faceShapeAdapter.getSelectedIndex())
                     .apply();
             requireActivity().onBackPressed();
         });
@@ -130,6 +135,15 @@ public class AvatarCustomizationFragment extends Fragment {
         skinAdapter = new AvatarOptionAdapter(skinOptions, pos -> updatePreview());
         skinRecycler.setLayoutManager(new LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false));
         skinRecycler.setAdapter(skinAdapter);
+
+        int[] faceShapeOptions = {
+                R.drawable.avatar_face,
+                R.drawable.avatar_face_square,
+                R.drawable.avatar_face_oval
+        };
+        faceShapeAdapter = new AvatarOptionAdapter(faceShapeOptions, pos -> updatePreview());
+        faceShapeRecycler.setLayoutManager(new LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false));
+        faceShapeRecycler.setAdapter(faceShapeAdapter);
 
         int[] hairOptions = {
                 R.drawable.avatar_hair_1,
@@ -223,6 +237,7 @@ public class AvatarCustomizationFragment extends Fragment {
         int ears = prefs.getInt(KEY_EARS, 0);
         int facial = prefs.getInt(KEY_FACIAL_HAIR, 0);
         int accessory = prefs.getInt(KEY_ACCESSORY, 0);
+        int faceShape = prefs.getInt(KEY_FACE_SHAPE, 0);
 
         skinAdapter.setSelectedIndex(skin);
         hairAdapter.setSelectedIndex(hair);
@@ -233,6 +248,7 @@ public class AvatarCustomizationFragment extends Fragment {
         earsAdapter.setSelectedIndex(ears);
         facialHairAdapter.setSelectedIndex(facial);
         accessoryAdapter.setSelectedIndex(accessory);
+        faceShapeAdapter.setSelectedIndex(faceShape);
         updatePreview();
     }
 
@@ -253,6 +269,19 @@ public class AvatarCustomizationFragment extends Fragment {
                 break;
             case 4:
                 faceView.setColorFilter(getResources().getColor(R.color.avatar_skin_very_dark));
+                break;
+        }
+
+        int faceShapePos = faceShapeAdapter != null ? faceShapeAdapter.getSelectedIndex() : 0;
+        switch (faceShapePos) {
+            case 0:
+                faceView.setImageResource(R.drawable.avatar_face);
+                break;
+            case 1:
+                faceView.setImageResource(R.drawable.avatar_face_square);
+                break;
+            case 2:
+                faceView.setImageResource(R.drawable.avatar_face_oval);
                 break;
         }
 

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -237,6 +237,7 @@ public class ProfileFragment extends Fragment {
         int ears = prefs.getInt(Constants.AVATAR_EARS, 0);
         int facial = prefs.getInt(Constants.AVATAR_FACIAL_HAIR, 0);
         int accessory = prefs.getInt(Constants.AVATAR_ACCESSORY, 0);
+        int faceShape = prefs.getInt(Constants.AVATAR_FACE_SHAPE, 0);
 
         switch (skin) {
             case 0:
@@ -253,6 +254,18 @@ public class ProfileFragment extends Fragment {
                 break;
             case 4:
                 avatarFace.setColorFilter(getResources().getColor(R.color.avatar_skin_very_dark));
+                break;
+        }
+
+        switch (faceShape) {
+            case 0:
+                avatarFace.setImageResource(R.drawable.avatar_face);
+                break;
+            case 1:
+                avatarFace.setImageResource(R.drawable.avatar_face_square);
+                break;
+            case 2:
+                avatarFace.setImageResource(R.drawable.avatar_face_oval);
                 break;
         }
 

--- a/app/src/main/java/com/gigamind/cognify/util/Constants.java
+++ b/app/src/main/java/com/gigamind/cognify/util/Constants.java
@@ -51,4 +51,5 @@ public class Constants {
     public static final String AVATAR_EARS = "avatar_ears";
     public static final String AVATAR_FACIAL_HAIR = "avatar_facial_hair";
     public static final String AVATAR_ACCESSORY = "avatar_accessory";
+    public static final String AVATAR_FACE_SHAPE = "avatar_face_shape";
 }

--- a/app/src/main/res/drawable/avatar_face_oval.xml
+++ b/app/src/main/res/drawable/avatar_face_oval.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path
+        android:fillColor="#FFCC99"
+        android:pathData="M50,10a40,45 0 1 1 0,80a40,45 0 1 1 0,-80" />
+</vector>

--- a/app/src/main/res/drawable/avatar_face_square.xml
+++ b/app/src/main/res/drawable/avatar_face_square.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path
+        android:fillColor="#FFCC99"
+        android:pathData="M5,5h90v90h-90z" />
+</vector>

--- a/app/src/main/res/layout/fragment_avatar_customization.xml
+++ b/app/src/main/res/layout/fragment_avatar_customization.xml
@@ -89,6 +89,22 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
+            android:text="@string/face_shape"
+            android:textColor="@color/text_primary"
+            android:textStyle="bold" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/faceShapeRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:overScrollMode="never"
+            android:scrollbars="none" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
             android:text="@string/hair_style"
             android:textColor="@color/text_primary"
             android:textStyle="bold" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="save">Save</string>
     <string name="customize_avatar">Customize Avatar</string>
     <string name="skin_color">Skin Color</string>
+    <string name="face_shape">Face Shape</string>
     <string name="hair_style">Hair Style</string>
     <string name="eyes_style">Eyes Style</string>
     <string name="mouth_style">Mouth Style</string>


### PR DESCRIPTION
## Summary
- allow avatar face shape selection with new `AVATAR_FACE_SHAPE` pref
- add UI to choose between round, square and oval faces
- apply selected face shape on profile screen
- include new drawable resources for square and oval faces

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850b7dd03608332a651406f10d29728