### PR TITLE
Fix avatar layering and reposition ears

### DIFF
--- a/app/src/main/res/drawable/avatar_ears_1.xml
+++ b/app/src/main/res/drawable/avatar_ears_1.xml
@@ -3,6 +3,7 @@
     android:height="100dp"
     android:viewportWidth="100"
     android:viewportHeight="100">
-    <path android:fillColor="#FFC107" android:pathData="M20,40 a5,8 0 1 0 0.1,0"/>
-    <path android:fillColor="#FFC107" android:pathData="M80,40 a5,8 0 1 0 0.1,0"/>
+    <!-- Move ears closer to the edge of the head -->
+    <path android:fillColor="#FFC107" android:pathData="M5,40 a5,8 0 1 0 0.1,0"/>
+    <path android:fillColor="#FFC107" android:pathData="M95,40 a5,8 0 1 0 0.1,0"/>
 </vector>

--- a/app/src/main/res/drawable/avatar_ears_2.xml
+++ b/app/src/main/res/drawable/avatar_ears_2.xml
@@ -3,6 +3,7 @@
     android:height="100dp"
     android:viewportWidth="100"
     android:viewportHeight="100">
-    <path android:fillColor="#FFB300" android:pathData="M18,40 a7,10 0 1 0 0.1,0"/>
-    <path android:fillColor="#FFB300" android:pathData="M82,40 a7,10 0 1 0 0.1,0"/>
+    <!-- Move ears closer to the edge of the head -->
+    <path android:fillColor="#FFB300" android:pathData="M5,40 a7,10 0 1 0 0.1,0"/>
+    <path android:fillColor="#FFB300" android:pathData="M95,40 a7,10 0 1 0 0.1,0"/>
 </vector>

--- a/app/src/main/res/drawable/avatar_ears_3.xml
+++ b/app/src/main/res/drawable/avatar_ears_3.xml
@@ -3,6 +3,7 @@
     android:height="100dp"
     android:viewportWidth="100"
     android:viewportHeight="100">
-    <path android:fillColor="#FFA000" android:pathData="M16,40 a9,12 0 1 0 0.1,0"/>
-    <path android:fillColor="#FFA000" android:pathData="M84,40 a9,12 0 1 0 0.1,0"/>
+    <!-- Move ears closer to the edge of the head -->
+    <path android:fillColor="#FFA000" android:pathData="M5,40 a9,12 0 1 0 0.1,0"/>
+    <path android:fillColor="#FFA000" android:pathData="M95,40 a9,12 0 1 0 0.1,0"/>
 </vector>

--- a/app/src/main/res/layout/fragment_avatar_customization.xml
+++ b/app/src/main/res/layout/fragment_avatar_customization.xml
@@ -20,6 +20,13 @@
                 android:layout_height="match_parent"
                 android:src="@drawable/avatar_body_1" />
 
+            <!-- Place ears behind the face so they appear attached -->
+            <ImageView
+                android:id="@+id/earsView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/avatar_ears_1" />
+
             <ImageView
                 android:id="@+id/faceView"
                 android:layout_width="match_parent"
@@ -49,12 +56,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:src="@drawable/avatar_nose_1" />
-
-            <ImageView
-                android:id="@+id/earsView"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:src="@drawable/avatar_ears_1" />
 
             <ImageView
                 android:id="@+id/facialHairView"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -80,6 +80,13 @@
                 android:layout_height="72dp"
                 android:layout_gravity="center">
 
+                <!-- Ears should appear behind the face -->
+                <ImageView
+                    android:id="@+id/avatarEars"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/avatar_ears_1" />
+
                 <ImageView
                     android:id="@+id/avatarFace"
                     android:layout_width="match_parent"
@@ -115,12 +122,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:src="@drawable/avatar_nose_1" />
-
-                <ImageView
-                    android:id="@+id/avatarEars"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:src="@drawable/avatar_ears_1" />
 
                 <ImageView
                     android:id="@+id/avatarFacialHair"


### PR DESCRIPTION
## Summary
- reorder avatar layers so ears are behind the head
- tweak ear vector positions to sit closer to the edges of the face

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850bb393da88332b1a689025fe44532