### PR TITLE
Add avatar customization options

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/avatar/AvatarMakerActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/avatar/AvatarMakerActivity.java
@@ -15,6 +15,9 @@ import java.util.List;
 
 public class AvatarMakerActivity extends AppCompatActivity {
     private ImageView hairView;
+    private ImageView eyesView;
+    private ImageView mouthView;
+    private ImageView skinView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -22,17 +25,53 @@ public class AvatarMakerActivity extends AppCompatActivity {
         setContentView(R.layout.activity_avatar_maker);
 
         hairView = findViewById(R.id.hairView);
-        RecyclerView recyclerView = findViewById(R.id.hairRecyclerView);
+        eyesView = findViewById(R.id.eyesView);
+        mouthView = findViewById(R.id.mouthView);
+        skinView = findViewById(R.id.skinView);
+
+        RecyclerView hairRecycler = findViewById(R.id.hairRecyclerView);
+        RecyclerView eyesRecycler = findViewById(R.id.eyesRecyclerView);
+        RecyclerView mouthRecycler = findViewById(R.id.mouthRecyclerView);
+        RecyclerView skinRecycler = findViewById(R.id.skinRecyclerView);
 
         List<Integer> hairOptions = Arrays.asList(
                 R.drawable.hair_long,
                 R.drawable.hair_bun,
-                R.drawable.hair_curly
+                R.drawable.hair_curly,
+                R.drawable.hair_longbob
         );
 
-        AvatarOptionAdapter adapter = new AvatarOptionAdapter(hairOptions, resId ->
+        AvatarOptionAdapter hairAdapter = new AvatarOptionAdapter(hairOptions, resId ->
                 hairView.setImageResource(resId));
-        recyclerView.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
-        recyclerView.setAdapter(adapter);
+        hairRecycler.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
+        hairRecycler.setAdapter(hairAdapter);
+
+        List<Integer> eyesOptions = Arrays.asList(
+                R.drawable.eyes_default,
+                R.drawable.eyes_happy,
+                R.drawable.eyes_hearts
+        );
+        AvatarOptionAdapter eyesAdapter = new AvatarOptionAdapter(eyesOptions, resId ->
+                eyesView.setImageResource(resId));
+        eyesRecycler.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
+        eyesRecycler.setAdapter(eyesAdapter);
+
+        List<Integer> mouthOptions = Arrays.asList(
+                R.drawable.mouth_smile,
+                R.drawable.mouth_twinkle
+        );
+        AvatarOptionAdapter mouthAdapter = new AvatarOptionAdapter(mouthOptions, resId ->
+                mouthView.setImageResource(resId));
+        mouthRecycler.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
+        mouthRecycler.setAdapter(mouthAdapter);
+
+        List<Integer> skinOptions = Arrays.asList(
+                R.drawable.skin_white,
+                R.drawable.skin_black
+        );
+        AvatarOptionAdapter skinAdapter = new AvatarOptionAdapter(skinOptions, resId ->
+                skinView.setImageResource(resId));
+        skinRecycler.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
+        skinRecycler.setAdapter(skinAdapter);
     }
 }

--- a/app/src/main/res/drawable/eyes_happy.xml
+++ b/app/src/main/res/drawable/eyes_happy.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="360dp"
+    android:height="360dp"
+    android:viewportWidth="360"
+    android:viewportHeight="360">
+    <path
+        android:fillColor="#B3000000"
+        android:pathData="M131 153c-1,0 0,2 1,1 2,-2 5,-3 11,-4 7,1 9,2 11,4 2,1 3,-1 2,-1 -1,-1 -5,-7 -13,-7 -7,0 -12,6 -12,7z"/>
+    <path
+        android:fillColor="#B3000000"
+        android:pathData="M202 153c0,0 1,2 2,1 2,-2 5,-3 11,-4 7,1 9,2 11,4 2,1 3,-1 2,-1 -1,-1 -5,-7 -13,-7 -7,0 -12,6 -13,7z"/>
+</vector>

--- a/app/src/main/res/drawable/eyes_hearts.xml
+++ b/app/src/main/res/drawable/eyes_hearts.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="360dp"
+    android:height="360dp"
+    android:viewportWidth="360"
+    android:viewportHeight="360">
+    <path
+        android:fillColor="#FC675E"
+        android:pathData="M138 138c4,0 7,2 9,5 1,-3 5,-5 8,-5 6,0 10,4 10,10 0,2 -1,5 -3,7 -5,5 -10,10 -15,16l-16 -16c-2,-2 -3,-5 -3,-7 0,-6 4,-10 10,-10z"/>
+    <path
+        android:fillColor="#FC675E"
+        android:pathData="M204 138c4,0 7,2 9,5 2,-3 5,-5 9,-5 5,0 10,4 10,10 0,2 -2,5 -3,7 -5,5 -11,10 -16,16l-16 -16c-2,-2 -3,-5 -3,-7 0,-6 5,-10 10,-10z"/>
+</vector>

--- a/app/src/main/res/drawable/hair_longbob.xml
+++ b/app/src/main/res/drawable/hair_longbob.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="360dp"
+    android:height="360dp"
+    android:viewportWidth="360"
+    android:viewportHeight="360">
+    <path
+        android:fillColor="#66000000"
+        android:pathData="M111 136c13,-4 18,-9 36,-29 2,-3 4,-6 5,-9 24,24 56,38 88,45l-6 -10c2,1 22,10 26,10 0,-14 -11,2 -11,-15 0,-38 -31,-69 -69,-69l0 0c-44,0 -69,35 -69,77z"/>
+    <path
+        android:fillColor="#bb7748"
+        android:pathData="M70 156l0 0c0,1 -1,3 -1,4l3 -3c17,7 84,-59 77,-72 10,16 55,44 80,49 -4,-7 -9,-10 -13,-17 16,11 53,33 72,38 -8,-32 -25,-73 -44,-95 -20,-22 -60,-22 -65,-22 -5,0 -45,-1 -65,22 -18,20 -34,61 -43,93 -1,1 -1,2 -1,3z"/>
+</vector>

--- a/app/src/main/res/drawable/mouth_twinkle.xml
+++ b/app/src/main/res/drawable/mouth_twinkle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="360dp"
+    android:height="360dp"
+    android:viewportWidth="360"
+    android:viewportHeight="360">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M162 200c-1,-2 0,-3 2,-3 1,-1 3,0 3,1 1,3 2,5 5,6 2,2 5,3 8,3 3,0 6,-1 8,-3 3,-1 4,-3 5,-6 0,-1 2,-2 3,-1 2,0 3,1 2,3 -1,3 -4,6 -7,9 -3,2 -7,3 -11,3 -4,0 -8,-1 -11,-3 -3,-3 -6,-6 -7,-9z"/>
+</vector>

--- a/app/src/main/res/drawable/skin_black.xml
+++ b/app/src/main/res/drawable/skin_black.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="360dp"
+    android:height="360dp"
+    android:viewportWidth="360"
+    android:viewportHeight="360">
+    <path
+        android:fillColor="#6c4f34"
+        android:pathData="M304 360l0 -15c0,-47 -39,-85 -86,-85l-8 0 0 -22c22,-10 37,-32 39,-57 7,-1 13,-7 13,-15l0 -15c0,-8 -6,-14 -13,-15l0 -8c0,-38 -31,-69 -69,-69l0 0c-38,0 -69,31 -69,69l0 8c-7,1 -13,7 -13,15l0 15c0,8 6,14 13,15 2,25 17,47 39,57l0 22 -8 0c-47,0 -86,38 -86,85l0 15 248 0z"/>
+    <path
+        android:fillColor="#33000000"
+        android:pathData="M180 256c-11,0 -21,-2 -30,-6l0,-12c9,5 19,7 30,7l0 0c11,0 21,-2 30,-7l0 12c-9,4 -19,6 -30,6z"/>
+    <path
+        android:fillColor="#33000000"
+        android:pathData="M180 181c9,0 16,-4 16,-9l-32 0c0,5 7,9 16,9z"/>
+</vector>

--- a/app/src/main/res/layout/activity_avatar_maker.xml
+++ b/app/src/main/res/layout/activity_avatar_maker.xml
@@ -47,4 +47,28 @@
         android:layout_marginTop="16dp"
         android:scrollbars="horizontal"
         tools:listitem="@layout/item_avatar_option" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/eyesRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:scrollbars="horizontal"
+        tools:listitem="@layout/item_avatar_option" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/mouthRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:scrollbars="horizontal"
+        tools:listitem="@layout/item_avatar_option" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/skinRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:scrollbars="horizontal"
+        tools:listitem="@layout/item_avatar_option" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- add new avatar assets for hair, eyes, mouth, and skin
- support selecting these options in `AvatarMakerActivity`
- extend layout with additional RecyclerViews for customization

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850c90000f08332ba70b7507d420393