### PR TITLE
Fix vector drawable attribute errors

### DIFF
--- a/app/src/main/res/drawable/acc_earring2.xml
+++ b/app/src/main/res/drawable/acc_earring2.xml
@@ -3,6 +3,10 @@
     android:height="160dp"
     android:viewportWidth="160"
     android:viewportHeight="160">
-    <circle android:fillColor="gold" android:cx="21" android:cy="60" android:r="9" />
-    <circle android:fillColor="gold" android:cx="89" android:cy="60" android:r="9" />
+    <path
+        android:fillColor="@color/gold"
+        android:pathData="M21,60m-9,0a9,9 0 1,0 18,0a9,9 0 1,0 -18,0" />
+    <path
+        android:fillColor="@color/gold"
+        android:pathData="M89,60m-9,0a9,9 0 1,0 18,0a9,9 0 1,0 -18,0" />
 </vector>


### PR DESCRIPTION
## Summary
- convert `acc_earring2.xml` to use `path` elements
- reference the defined `@color/gold` resource for fill color

## Testing
- `./gradlew test --stacktrace` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850f7572eb88332aaae47ed5b547ced