### PR TITLE
Fix vector drawable circle attributes

### DIFF
--- a/app/src/main/res/drawable/eyes_surprised.xml
+++ b/app/src/main/res/drawable/eyes_surprised.xml
@@ -3,8 +3,18 @@
     android:height="150dp"
     android:viewportWidth="150"
     android:viewportHeight="150">
-    <circle android:fillColor="#FEFEFE" android:cx="48" android:cy="100" android:r="17" />
-    <circle android:fillColor="#4D4D4D" android:strokeColor="#5F4A37" android:strokeWidth="0.9" android:cx="48" android:cy="100" android:r="8" />
-    <circle android:fillColor="#FEFEFE" android:cx="112" android:cy="100" android:r="17" />
-    <circle android:fillColor="#4D4D4D" android:cx="112" android:cy="100" android:r="8" />
+    <path
+        android:fillColor="#FEFEFE"
+        android:pathData="M48 100m-17 0a17 17 0 1 0 34 0a17 17 0 1 0 -34 0" />
+    <path
+        android:fillColor="#4D4D4D"
+        android:strokeColor="#5F4A37"
+        android:strokeWidth="0.9"
+        android:pathData="M48 100m-8 0a8 8 0 1 0 16 0a8 8 0 1 0 -16 0" />
+    <path
+        android:fillColor="#FEFEFE"
+        android:pathData="M112 100m-17 0a17 17 0 1 0 34 0a17 17 0 1 0 -34 0" />
+    <path
+        android:fillColor="#4D4D4D"
+        android:pathData="M112 100m-8 0a8 8 0 1 0 16 0a8 8 0 1 0 -16 0" />
 </vector>

--- a/app/src/main/res/drawable/eyes_winkwacky.xml
+++ b/app/src/main/res/drawable/eyes_winkwacky.xml
@@ -4,6 +4,10 @@
     android:viewportWidth="150"
     android:viewportHeight="150">
     <path android:fillColor="#B3000000" android:pathData="M31 106c-1,1 0,3 1,1 2,-1 5,-3 11,-3 7,0 9,2 11,3 2,2 3,0 2,-1 -1,-1 -5,-7 -13,-7 -7,0 -12,6 -12,7z"/>
-    <circle android:fillColor="#FEFEFE" android:cx="112" android:cy="103" android:r="15" />
-    <circle android:fillColor="#4D4D4D" android:cx="112" android:cy="103" android:r="8" />
+    <path
+        android:fillColor="#FEFEFE"
+        android:pathData="M112 103m-15 0a15 15 0 1 0 30 0a15 15 0 1 0 -30 0" />
+    <path
+        android:fillColor="#4D4D4D"
+        android:pathData="M112 103m-8 0a8 8 0 1 0 16 0a8 8 0 1 0 -16 0" />
 </vector>


### PR DESCRIPTION
## Summary
- replace invalid `<circle>` elements with path data in vector drawables

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850f81acc20833299d536950215f0ae