### PR TITLE
Fix default selection highlight in avatar maker

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/adapter/AvatarOptionAdapter.java
+++ b/app/src/main/java/com/gigamind/cognify/adapter/AvatarOptionAdapter.java
@@ -34,11 +34,16 @@ public class AvatarOptionAdapter extends RecyclerView.Adapter<AvatarOptionAdapte
 
     private final List<AvatarOption> items;
     private final OnOptionClickListener listener;
-    private int selectedPosition = RecyclerView.NO_POSITION;
+    private int selectedPosition;
 
     public AvatarOptionAdapter(List<AvatarOption> items, OnOptionClickListener listener) {
+        this(items, listener, 0);
+    }
+
+    public AvatarOptionAdapter(List<AvatarOption> items, OnOptionClickListener listener, int initialSelectedPosition) {
         this.items = items;
         this.listener = listener;
+        this.selectedPosition = initialSelectedPosition;
     }
 
     @NonNull


### PR DESCRIPTION
## Summary
- highlight default options in the avatar creator by selecting the first option when the adapter is created

## Testing
- `./gradlew test --daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68511d568da88332bec621cf6dd245ff