### PR TITLE
Fix tutorial popup truncation

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/TutorialOverlay.java
@@ -105,9 +105,16 @@ public class TutorialOverlay {
         scrim.setHole(hole);
         view.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
         int popupHeight = view.getMeasuredHeight();
+        int popupWidth = view.getMeasuredWidth();
         int y = loc[1] - popupHeight;
         if (y < 0) y = loc[1] + step.anchor.getHeight();
-        popup.showAtLocation(step.anchor, Gravity.NO_GRAVITY, loc[0], y);
+        int x = loc[0];
+        int screenWidth = root.getWidth();
+        if (x + popupWidth > screenWidth) {
+            x = screenWidth - popupWidth;
+        }
+        if (x < 0) x = 0;
+        popup.showAtLocation(step.anchor, Gravity.NO_GRAVITY, x, y);
 
         next.setOnClickListener(v -> {
             popup.dismiss();


### PR DESCRIPTION
## Summary
- keep tutorial overlay popups inside the screen

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685130dd15b88332a6cb080de2fe1984