### PR TITLE
Add QuickMath tutorial overlay

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,6 +219,10 @@
     <string name="tutorial_got_it">Start Game</string>
     <string name="tutorial_skip">Skip Tutorial</string>
 
+    <!-- Quick Math tutorial strings -->
+    <string name="math_tutorial_step_equation">Solve the equation shown here.</string>
+    <string name="math_tutorial_step_options">Tap an option to answer.</string>
+
     <string name="loading_dictionary">Loading words...</string>
     <string name="dictionary_loaded">Words ready</string>
 


### PR DESCRIPTION
## Summary
- implement tutorial overlay in `QuickMathActivity`
- add Quick Math tutorial strings

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68513ba5938c8332906f93d71f629c7c