### PR TITLE
Implement score penalty for wrong answers

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/engine/MathGameEngine.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/MathGameEngine.java
@@ -76,7 +76,7 @@ public class MathGameEngine {
     }
 
     public int getScore(boolean correct) {
-        return correct ? 10 : 0;
+        return correct ? 10 : -5;
     }
 
     public int getCurrentAnswer() {

--- a/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
@@ -56,6 +56,6 @@ public class MathGameEngineTest {
         assertFalse(engine.checkAnswer(correct + 1));
 
         assertEquals(10, engine.getScore(true));
-        assertEquals(0, engine.getScore(false));
+        assertEquals(-5, engine.getScore(false));
     }
 }


### PR DESCRIPTION
## Summary
- add a -5 point penalty for incorrect answers in `MathGameEngine`
- update unit test to expect negative penalty

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68513c1865788332b09be5789c69e73f