### PR TITLE
Upload avatars to Firebase Storage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.firebase:firebase-firestore")
     implementation("com.google.firebase:firebase-crashlytics")
+    implementation(libs.firebase.storage)
     
     // Lottie for animations
     implementation("com.airbnb.android:lottie:6.4.0")
@@ -68,6 +69,7 @@ dependencies {
     implementation(libs.googleid)
     implementation(libs.firebase.ai)
     implementation(libs.circleimageview)
+    implementation(libs.glide)
     implementation("com.google.android.flexbox:flexbox:3.0.0")
 
     testImplementation(libs.junit)

--- a/app/src/main/java/com/gigamind/cognify/data/firebase/FirebaseService.java
+++ b/app/src/main/java/com/gigamind/cognify/data/firebase/FirebaseService.java
@@ -5,6 +5,7 @@ import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.SetOptions;
+import com.google.firebase.storage.FirebaseStorage;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 
@@ -15,6 +16,7 @@ public class FirebaseService {
     private static FirebaseService instance;
     private final FirebaseAuth auth;
     private final FirebaseFirestore firestore;
+    private final FirebaseStorage storage;
 
     // Collection paths
     public static final String COLLECTION_USERS = "users";
@@ -23,6 +25,7 @@ public class FirebaseService {
     private FirebaseService() {
         auth = FirebaseAuth.getInstance();
         firestore = FirebaseFirestore.getInstance();
+        storage = FirebaseStorage.getInstance();
     }
 
     public static synchronized FirebaseService getInstance() {
@@ -38,6 +41,10 @@ public class FirebaseService {
 
     public FirebaseFirestore getFirestore() {
         return firestore;
+    }
+
+    public FirebaseStorage getStorage() {
+        return storage;
     }
 
     public FirebaseUser getCurrentUser() {

--- a/app/src/main/java/com/gigamind/cognify/ui/avatar/AvatarMakerActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/avatar/AvatarMakerActivity.java
@@ -3,11 +3,9 @@ package com.gigamind.cognify.ui.avatar;
 import android.os.Bundle;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.util.Base64;
 import android.widget.ImageView;
 import android.widget.Button;
 import android.widget.FrameLayout;
-import java.io.ByteArrayOutputStream;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -176,12 +174,9 @@ public class AvatarMakerActivity extends AppCompatActivity {
             Bitmap bitmap = Bitmap.createBitmap(avatarContainer.getWidth(), avatarContainer.getHeight(), Bitmap.Config.ARGB_8888);
             Canvas canvas = new Canvas(bitmap);
             avatarContainer.draw(canvas);
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, baos);
-            String encoded = Base64.encodeToString(baos.toByteArray(), Base64.DEFAULT);
 
-            userRepository.saveProfilePicture(encoded);
-            finish();
+            userRepository.saveProfilePicture(bitmap)
+                    .addOnSuccessListener(task -> finish());
         });
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -15,6 +15,7 @@ import android.widget.ImageView;
 import android.util.Base64;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import com.bumptech.glide.Glide;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -151,11 +152,15 @@ public class HomeFragment extends Fragment {
     }
 
     private void loadAvatar() {
-        String encoded = userRepository.getProfilePicture();
-        if (encoded != null && !encoded.isEmpty()) {
-            byte[] bytes = Base64.decode(encoded, Base64.DEFAULT);
-            Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
-            currentUserAvatar.setImageBitmap(bmp);
+        String stored = userRepository.getProfilePicture();
+        if (stored != null && !stored.isEmpty()) {
+            if (stored.startsWith("http")) {
+                Glide.with(this).load(stored).into(currentUserAvatar);
+            } else {
+                byte[] bytes = Base64.decode(stored, Base64.DEFAULT);
+                Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+                currentUserAvatar.setImageBitmap(bmp);
+            }
         }
     }
 

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 import android.util.Base64;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import com.bumptech.glide.Glide;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -156,9 +157,13 @@ public class ProfileFragment extends Fragment {
                             String rate = total > 0 ? (100 * wins / total) + "%" : "0%";
                             winRateValue.setText(rate);
                             if (encodedPic != null && !encodedPic.isEmpty()) {
-                                byte[] bytes = Base64.decode(encodedPic, Base64.DEFAULT);
-                                Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
-                                profileAvatar.setImageBitmap(bmp);
+                                if (encodedPic.startsWith("http")) {
+                                    Glide.with(ProfileFragment.this).load(encodedPic).into(profileAvatar);
+                                } else {
+                                    byte[] bytes = Base64.decode(encodedPic, Base64.DEFAULT);
+                                    Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+                                    profileAvatar.setImageBitmap(bmp);
+                                }
                             }
                         });
                     }
@@ -224,11 +229,15 @@ public class ProfileFragment extends Fragment {
     }
 
     private void loadAvatar() {
-        String encoded = userRepository.getProfilePicture();
-        if (encoded != null && !encoded.isEmpty()) {
-            byte[] bytes = Base64.decode(encoded, Base64.DEFAULT);
-            Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
-            profileAvatar.setImageBitmap(bmp);
+        String stored = userRepository.getProfilePicture();
+        if (stored != null && !stored.isEmpty()) {
+            if (stored.startsWith("http")) {
+                Glide.with(this).load(stored).into(profileAvatar);
+            } else {
+                byte[] bytes = Base64.decode(stored, Base64.DEFAULT);
+                Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+                profileAvatar.setImageBitmap(bmp);
+            }
         }
     }
 

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import android.util.Base64;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import com.bumptech.glide.Glide;
 import com.google.android.material.snackbar.Snackbar;
 
 import androidx.annotation.NonNull;
@@ -118,11 +119,15 @@ public class WordDashFragment extends Fragment {
     }
 
     private void loadAvatar() {
-        String encoded = userRepository.getProfilePicture();
-        if (encoded != null && !encoded.isEmpty()) {
-            byte[] bytes = Base64.decode(encoded, Base64.DEFAULT);
-            Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
-            userProfileButton.setImageBitmap(bmp);
+        String stored = userRepository.getProfilePicture();
+        if (stored != null && !stored.isEmpty()) {
+            if (stored.startsWith("http")) {
+                Glide.with(this).load(stored).into(userProfileButton);
+            } else {
+                byte[] bytes = Base64.decode(stored, Base64.DEFAULT);
+                Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+                userProfileButton.setImageBitmap(bmp);
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ credentials = "1.5.0"
 credentialsPlayServicesAuth = "1.5.0"
 googleid = "1.1.1"
 firebaseAi = "16.0.0"
+glide = "4.16.0"
+firebaseStorage = "20.3.0"
 
 [libraries]
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
@@ -44,6 +46,8 @@ credentials-play-services-auth = { group = "androidx.credentials", name = "crede
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
 firebase-ai = { group = "com.google.firebase", name = "firebase-ai", version.ref = "firebaseAi" }
 circleimageview = { module = "de.hdodenhof:circleimageview", version.ref = "circleimageview" }
+glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
+firebase-storage = { group = "com.google.firebase", name = "firebase-storage", version.ref = "firebaseStorage" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- save user profile photos to Cloud Storage and keep the URL in Firestore
- handle avatar URLs in profile, home and word dash UIs
- add Glide for image loading
- add Firebase Storage and Glide dependencies
- expose FirebaseStorage in FirebaseService

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68513fdb61f883329fb0480ee5856bf1