### PR TITLE
Add circular avatar views

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -11,7 +11,7 @@ import android.view.ViewGroup;
 import android.view.animation.AnimationUtils;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.ImageView;
+import de.hdodenhof.circleimageview.CircleImageView;
 import android.util.Base64;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -58,7 +58,7 @@ public class HomeFragment extends Fragment {
     private TextView questTitle;
     private TextView questDescription;
     private TextView questReward;
-    private ImageView currentUserAvatar;
+    private CircleImageView currentUserAvatar;
     private SharedPreferences prefs;
     private UserRepository userRepository;
     private FirebaseUser firebaseUser;

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
+import de.hdodenhof.circleimageview.CircleImageView;
 import android.widget.TextView;
 import android.util.Base64;
 import android.graphics.Bitmap;
@@ -49,7 +50,7 @@ public class ProfileFragment extends Fragment {
     private Button inviteFriendsButton;
     private Button shareStreakButton;
     private Button trophyRoomButton;
-    private ImageView profileAvatar;
+    private CircleImageView profileAvatar;
 
     private UserRepository userRepository;
     private FirebaseUser firebaseUser;

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
+import de.hdodenhof.circleimageview.CircleImageView;
 import android.widget.TextView;
 import android.util.Base64;
 import android.graphics.Bitmap;
@@ -50,7 +51,7 @@ public class WordDashFragment extends Fragment {
     private UserRepository userRepository;
     private FirebaseUser firebaseUser;
     private ListenerRegistration homeListener;
-    private ImageView userProfileButton;
+    private CircleImageView userProfileButton;
     private TutorialHelper tutorialHelper;
 
     @Nullable

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -54,7 +54,7 @@
                 android:textSize="24sp"
                 android:textStyle="bold" />
 
-            <ImageView
+            <de.hdodenhof.circleimageview.CircleImageView
                 android:id="@+id/currentUserAvatar"
                 android:layout_width="48dp"
                 android:layout_height="48dp"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -111,13 +111,13 @@
 
                 </LinearLayout>
 
-                <ImageView
+                <de.hdodenhof.circleimageview.CircleImageView
                     android:id="@+id/profileAvatar"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_weight="0.2"
                     android:layout_gravity="center"
-                    android:scaleType="fitCenter"
+                    android:scaleType="centerCrop"
                     android:src="@drawable/ic_avatar"/>
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_word_dash.xml
+++ b/app/src/main/res/layout/fragment_word_dash.xml
@@ -52,15 +52,14 @@
                 android:textSize="24sp"
                 android:textStyle="bold" />
 
-            <ImageView
+            <de.hdodenhof.circleimageview.CircleImageView
                 android:id="@+id/currentUserAvatar"
                 android:layout_width="48dp"
                 android:layout_height="48dp"
-                android:scaleType="fitCenter"
+                android:scaleType="centerCrop"
                 android:layout_gravity="center"
                 android:src="@drawable/ic_avatar"
-                android:layout_weight="1"
-                 />
+                android:layout_weight="1" />
         </LinearLayout>
 
             <LinearLayout


### PR DESCRIPTION
## Summary
- display profile images using CircleImageView
- use CircleImageView types in Profile, Home and WordDash fragments

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*


------
https://chatgpt.com/codex/tasks/task_e_6851d22a9bbc8332b8cf63fd367d174d