### PR TITLE
Fix account deletion flow

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/data/firebase/FirebaseService.java
+++ b/app/src/main/java/com/gigamind/cognify/data/firebase/FirebaseService.java
@@ -119,6 +119,11 @@ public class FirebaseService {
                 .document(uid)
                 .delete();
 
-        return deleteData.continueWithTask(task -> user.delete());
+        return deleteData.continueWithTask(task -> {
+            if (!task.isSuccessful()) {
+                return Tasks.forException(task.getException());
+            }
+            return user.delete();
+        }).addOnCompleteListener(t -> signOut());
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -194,7 +194,7 @@ public class SettingsFragment extends Fragment {
         user.reauthenticate(credential)
                 .addOnSuccessListener(aVoid -> FirebaseService.getInstance().deleteAccountAndData()
                         .addOnSuccessListener(v -> {
-                            String msg = getString(R.string.sign_out);
+                            String msg = getString(R.string.account_deleted);
                             Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_SHORT).show();
                             binding.getRoot().announceForAccessibility(msg);
                             startActivity(new Intent(requireActivity(), OnboardingActivity.class)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,5 +232,6 @@
     <string name="hair_bun">Hair Bun</string>
     <string name="hair_curly">Curly Hair</string>
     <string name="delete_account_error">Failed to delete account: %1$s</string>
+    <string name="account_deleted">Account deleted successfully</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- handle firestore deletion failure before removing user
- announce account deleted instead of sign out
- add `account_deleted` string resource

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851d64e5af48332a7068ede469641b3