### PR TITLE
Add haptic feedback with sound effects

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.VIBRATE" />
     <application
         android:name=".CognifyApplication"
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- enable vibration permission in the manifest
- integrate `Vibrator` inside `SoundManager`
- automatically trigger a short haptic pulse whenever a sound effect plays

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851d7651cc88332a8f67c355ab3eb10