### PR TITLE
Handle missing Play Services gracefully during sign in

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -179,8 +179,25 @@ public class OnboardingActivity extends AppCompatActivity {
     }
 
     private void signIn() {
-        Intent signInIntent = googleSignInClient.getSignInIntent();
-        startActivityForResult(signInIntent, RC_SIGN_IN);
+        int status = com.google.android.gms.common.GoogleApiAvailability
+                .getInstance()
+                .isGooglePlayServicesAvailable(this);
+        if (status != com.google.android.gms.common.ConnectionResult.SUCCESS) {
+            String msg = getString(R.string.play_services_required);
+            Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+            binding.getRoot().announceForAccessibility(msg);
+            return;
+        }
+
+        try {
+            Intent signInIntent = googleSignInClient.getSignInIntent();
+            startActivityForResult(signInIntent, RC_SIGN_IN);
+        } catch (Exception e) {
+            ExceptionLogger.log("OnboardingActivity", e);
+            String msg = getString(R.string.google_sign_in_failed);
+            Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+            binding.getRoot().announceForAccessibility(msg);
+        }
     }
 
     private void continueAsGuest() {

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -177,12 +177,28 @@ public class SettingsFragment extends Fragment {
     }
 
     private void startDeleteFlow() {
+        int status = com.google.android.gms.common.GoogleApiAvailability
+                .getInstance()
+                .isGooglePlayServicesAvailable(requireContext());
+        if (status != com.google.android.gms.common.ConnectionResult.SUCCESS) {
+            String msg = getString(R.string.play_services_required);
+            Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+            binding.getRoot().announceForAccessibility(msg);
+            return;
+        }
+
         GoogleSignInAccount account = GoogleSignIn.getLastSignedInAccount(requireContext());
         if (account != null && account.getIdToken() != null) {
             reauthenticateAndDelete(account.getIdToken());
         } else {
-            Intent intent = googleSignInClient.getSignInIntent();
-            startActivityForResult(intent, RC_REAUTH);
+            try {
+                Intent intent = googleSignInClient.getSignInIntent();
+                startActivityForResult(intent, RC_REAUTH);
+            } catch (Exception e) {
+                String msg = getString(R.string.google_sign_in_failed);
+                Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+                binding.getRoot().announceForAccessibility(msg);
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,5 +233,7 @@
     <string name="hair_curly">Curly Hair</string>
     <string name="delete_account_error">Failed to delete account: %1$s</string>
     <string name="account_deleted">Account deleted successfully</string>
+    <string name="play_services_required">Google Play Services required for sign in.</string>
+    <string name="google_sign_in_failed">Google sign in failed.</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- improve Google sign in by checking Play Services
- show friendly error if Play Services or sign in is unavailable

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851d92923b08332b20144adf65f7ec8