### PR TITLE
Allow haptics when sound disabled

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/util/SoundManager.java
+++ b/app/src/main/java/com/gigamind/cognify/util/SoundManager.java
@@ -60,9 +60,8 @@ public class SoundManager {
         soundPool.setOnLoadCompleteListener((sp, sampleId, status) -> {
             if (status == 0) {
                 loadedMap.put(sampleId, true);
-                if (pendingSounds.remove(sampleId)) {
+                if (pendingSounds.remove(sampleId) && isSoundEnabled()) {
                     sp.play(sampleId, 1f, 1f, 0, 0, 1f);
-                    triggerHaptic();
                 }
             }
         });
@@ -96,14 +95,16 @@ public class SoundManager {
     }
 
     private void playSound(int soundId) {
-        if (!isSoundEnabled()) return;
-        Boolean isLoaded = loadedMap.get(soundId);
-        if (isLoaded != null && isLoaded) {
-            soundPool.play(soundId, 1f, 1f, 0, 0, 1f);
-            triggerHaptic();
-        } else {
-            pendingSounds.add(soundId);
+        boolean soundEnabled = isSoundEnabled();
+        if (soundEnabled) {
+            Boolean isLoaded = loadedMap.get(soundId);
+            if (isLoaded != null && isLoaded) {
+                soundPool.play(soundId, 1f, 1f, 0, 0, 1f);
+            } else {
+                pendingSounds.add(soundId);
+            }
         }
+        triggerHaptic();
     }
 
     private boolean isSoundEnabled() {


### PR DESCRIPTION
## Summary
- play haptics regardless of sound toggle
- guard sound playback when user disables sound effects

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851d97ff38c83329bbd3d715c89c279