### PR TITLE
Enable Firebase App Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - 👑 **Leaderboards** – Compete globally when you sign in with Google.
 - 🔔 **Notifications** – Never miss a session thanks to scheduled reminders.
 - 💖 **Guest Mode** – Try the game instantly; sync progress later via Firebase.
+- 🔒 **Firebase App Check** – Ensures only genuine app installs can access the backend.
 
 <p align="center">
   <img src="app/src/main/res/drawable/brain_train.png" alt="Brain Train" width="100"/>
@@ -21,7 +22,8 @@
 
 1. Clone this repository.
 2. Place your `google-services.json` file in the `app/` directory for Firebase.
-3. Build and run in Android Studio or execute:
+3. Firebase App Check is enabled automatically. Debug builds use the Debug provider.
+4. Build and run in Android Studio or execute:
    ```bash
    ./gradlew assembleDebug
    ```

--- a/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
+++ b/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
@@ -15,7 +15,7 @@ import com.gigamind.cognify.work.QuestNotificationScheduler;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.appcheck.BuildConfig;
+import com.gigamind.cognify.BuildConfig;
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.google.firebase.firestore.DocumentSnapshot;
@@ -68,6 +68,7 @@ public class CognifyApplication extends Application {
             firebaseAppCheck.installAppCheckProviderFactory(
                     PlayIntegrityAppCheckProviderFactory.getInstance());
         }
+        firebaseAppCheck.setTokenAutoRefreshEnabled(true);
         FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true);
 
         // (1b) Preload dictionary (so WordDashActivity doesn't flash an empty grid)


### PR DESCRIPTION
## Summary
- fix BuildConfig import to use app module's package
- enable automatic token refresh for Firebase App Check
- document Firebase App Check support in README

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851e3f4168483329be9e5b0bbd122c2