### PR TITLE
Improve exception logging

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/util/ExceptionLogger.java
+++ b/app/src/main/java/com/gigamind/cognify/util/ExceptionLogger.java
@@ -1,9 +1,13 @@
 package com.gigamind.cognify.util;
 
 import android.util.Log;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 /**
  * Utility class for centralized exception logging throughout the app.
+ * <p>
+ * All exceptions are written to logcat and forwarded to Firebase Crashlytics
+ * so issues can be monitored remotely.
  */
 public final class ExceptionLogger {
     private static final String DEFAULT_TAG = "ExceptionLogger";
@@ -14,7 +18,12 @@ public final class ExceptionLogger {
 
     public static void log(String tag, Throwable t) {
         if (t == null) return;
-        Log.e(tag != null ? tag : DEFAULT_TAG, t.getMessage(), t);
+        String logTag = tag != null ? tag : DEFAULT_TAG;
+        Log.e(logTag, t.getMessage(), t);
+
+        FirebaseCrashlytics crashlytics = FirebaseCrashlytics.getInstance();
+        crashlytics.log(logTag + ": " + t.getMessage());
+        crashlytics.recordException(t);
     }
 
     public static void log(Throwable t) {


### PR DESCRIPTION
## Summary
- log uncaught exceptions and other errors to Firebase Crashlytics in `ExceptionLogger`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851e4f354908332b7d971674fbbb344