### PR TITLE
Ensure exceptions logged to Crashlytics

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/SplashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/SplashActivity.java
@@ -14,6 +14,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.gigamind.cognify.databinding.ActivitySplashBinding;
 import com.gigamind.cognify.util.Constants;
 import com.gigamind.cognify.util.SoundManager;
+import com.gigamind.cognify.util.ExceptionLogger;
 
 public class SplashActivity extends AppCompatActivity {
     private ActivitySplashBinding binding;
@@ -55,7 +56,9 @@ public class SplashActivity extends AppCompatActivity {
                     try {
                         int s = Integer.parseInt(scoreStr);
                         gameIntent.putExtra(Constants.EXTRA_CHALLENGE_SCORE, s);
-                    } catch (NumberFormatException ignored) {}
+                    } catch (NumberFormatException e) {
+                        ExceptionLogger.log("SplashActivity", e);
+                    }
                 }
                 gameIntent.putExtra(Constants.EXTRA_CHALLENGE_TYPE, type);
                 startActivity(gameIntent);

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -32,6 +32,7 @@ import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.GoogleAuthProvider;
 import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
+import com.gigamind.cognify.util.ExceptionLogger;
 
 public class SettingsFragment extends Fragment {
     private FragmentSettingsBinding binding;
@@ -203,6 +204,7 @@ public class SettingsFragment extends Fragment {
             Intent intent = googleSignInClient.getSignInIntent();
             startActivityForResult(intent, RC_REAUTH);
         } catch (Exception e) {
+            ExceptionLogger.log("SettingsFragment", e);
             String msg = getString(R.string.google_sign_in_failed);
             Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
             binding.getRoot().announceForAccessibility(msg);
@@ -250,6 +252,7 @@ public class SettingsFragment extends Fragment {
                     reauthenticateAndDelete(account.getIdToken());
                 }
             } catch (ApiException e) {
+                ExceptionLogger.log("SettingsFragment", e);
                 String msg = getString(R.string.delete_account_error, e.getMessage());
                 Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
                 binding.getRoot().announceForAccessibility(msg);


### PR DESCRIPTION
## Summary
- log exception when deep link score fails to parse
- capture failed sign-in attempts in settings screen
- include ExceptionLogger dependency in SettingsFragment

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851e5cff9748332ad063244d3c37a7d