### PR TITLE
Add crashlytics logging on failures

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -248,6 +248,7 @@ public class OnboardingActivity extends AppCompatActivity {
                                 gAccount.getEmail()
                         ).addOnSuccessListener(v -> launchMainActivity())
                          .addOnFailureListener(err -> {
+                             ExceptionLogger.log("OnboardingActivity", err);
                              String msg = "Failed to update profile: " + err.getMessage();
                              Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
                              binding.getRoot().announceForAccessibility(msg);
@@ -259,6 +260,7 @@ public class OnboardingActivity extends AppCompatActivity {
                     }
                 })
                 .addOnFailureListener(e -> {
+                    ExceptionLogger.log("OnboardingActivity", e);
                     String msg = "Firebase authentication failed: " + e.getMessage();
                     Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
                     binding.getRoot().announceForAccessibility(msg);

--- a/app/src/main/java/com/gigamind/cognify/ui/leaderboard/LeaderboardViewModel.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/leaderboard/LeaderboardViewModel.java
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel;
 
 import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.gigamind.cognify.util.UserFields;
+import com.gigamind.cognify.util.ExceptionLogger;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.Query;
@@ -65,6 +66,7 @@ public class LeaderboardViewModel extends ViewModel {
                     isFetching = false;
                 })
                 .addOnFailureListener(e -> {
+                    ExceptionLogger.log("LeaderboardViewModel", e);
                     // You could post an empty list or a special “error” sentinel.  For simplicity,
                     // we'll post null to indicate failure; the fragment can check for null.
                     _leaderboard.postValue(null);

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -226,6 +226,7 @@ public class SettingsFragment extends Fragment {
                                     .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK));
                         })
                         .addOnFailureListener(e -> {
+                            ExceptionLogger.log("SettingsFragment", e);
                             String msg = getString(R.string.delete_account_error, e.getMessage());
                             Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
                             binding.getRoot().announceForAccessibility(msg);
@@ -234,6 +235,7 @@ public class SettingsFragment extends Fragment {
                     if (e instanceof FirebaseAuthInvalidCredentialsException) {
                         launchSignInIntent();
                     } else {
+                        ExceptionLogger.log("SettingsFragment", e);
                         String msg = getString(R.string.delete_account_error, e.getMessage());
                         Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
                         binding.getRoot().announceForAccessibility(msg);


### PR DESCRIPTION
## Summary
- include ExceptionLogger on failed profile update or sign-in
- log reauthentication errors from settings
- log leaderboard fetch errors to Crashlytics

## Testing
- `./gradlew test --dry-run` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851e6e2108c8332b18a0a84248e2336