### PR TITLE
Refactor styles across layouts

### DIFF
--- a/app/src/main/res/layout/activity_quick_math.xml
+++ b/app/src/main/res/layout/activity_quick_math.xml
@@ -35,9 +35,7 @@
             android:gravity="center"
             android:text="@string/word_dash_score_placeholder"
             android:layout_weight="8"
-            android:textColor="@android:color/white"
-            android:textSize="24sp"
-            android:textStyle="bold" />
+            style="@style/TextAppearance.Title" />
 
         <LinearLayout
             android:layout_width="wrap_content"
@@ -90,53 +88,41 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer1Button"
+            style="@style/Button.Answer"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="16dp"
             android:layout_columnWeight="1"
-            android:layout_rowWeight="1"
-            android:backgroundTint="@color/button_background"
-            android:padding="16dp"
-            android:textColor="@color/text_primary"
-            android:textSize="24sp" />
+            android:layout_rowWeight="1" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer2Button"
+            style="@style/Button.Answer"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginBottom="16dp"
             android:layout_columnWeight="1"
-            android:layout_rowWeight="1"
-            android:backgroundTint="@color/button_background"
-            android:padding="16dp"
-            android:textColor="@color/text_primary"
-            android:textSize="24sp" />
+            android:layout_rowWeight="1" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer3Button"
+            style="@style/Button.Answer"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
             android:layout_columnWeight="1"
-            android:layout_rowWeight="1"
-            android:backgroundTint="@color/button_background"
-            android:padding="16dp"
-            android:textColor="@color/text_primary"
-            android:textSize="24sp" />
+            android:layout_rowWeight="1" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer4Button"
+            style="@style/Button.Answer"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_columnWeight="1"
-            android:layout_rowWeight="1"
-            android:backgroundTint="@color/button_background"
-            android:padding="16dp"
-            android:textColor="@color/text_primary"
-            android:textSize="24sp" />
+            android:layout_rowWeight="1" />
     </GridLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_trophy_room.xml
+++ b/app/src/main/res/layout/activity_trophy_room.xml
@@ -13,9 +13,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/trophy_room"
-            android:textColor="@android:color/white"
-            android:textSize="24sp"
-            android:textStyle="bold" />
+            style="@style/TextAppearance.Title" />
 
         <LinearLayout
             android:id="@+id/trophyList"

--- a/app/src/main/res/layout/activity_word_dash.xml
+++ b/app/src/main/res/layout/activity_word_dash.xml
@@ -35,9 +35,7 @@
             android:gravity="center"
             android:text="@string/word_dash_score_placeholder"
             android:layout_weight="8"
-            android:textColor="@android:color/white"
-            android:textSize="24sp"
-            android:textStyle="bold" />
+            style="@style/TextAppearance.Title" />
 
         <LinearLayout
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -50,9 +50,7 @@
                 android:layout_weight="8"
                 android:gravity="center"
                 android:text="@string/home"
-                android:textColor="@android:color/white"
-                android:textSize="24sp"
-                android:textStyle="bold" />
+                style="@style/TextAppearance.Title" />
 
             <de.hdodenhof.circleimageview.CircleImageView
                 android:id="@+id/currentUserAvatar"

--- a/app/src/main/res/layout/fragment_leaderboard.xml
+++ b/app/src/main/res/layout/fragment_leaderboard.xml
@@ -23,9 +23,7 @@
             android:layout_gravity="center"
             android:gravity="center"
             android:text="@string/leaderboards"
-            android:textColor="@android:color/white"
-            android:textSize="24sp"
-            android:textStyle="bold" />
+            style="@style/TextAppearance.Title" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -51,9 +51,7 @@
                 android:layout_weight="8"
                 android:gravity="center"
                 android:text="@string/profile"
-                android:textColor="@android:color/white"
-                android:textSize="24sp"
-                android:textStyle="bold" />
+                style="@style/TextAppearance.Title" />
 
             <ImageView
                 android:id="@+id/settingsIcon"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -50,9 +50,7 @@
                 android:layout_weight="8"
                 android:gravity="center"
                 android:text="@string/settings"
-                android:textColor="@android:color/white"
-                android:textSize="24sp"
-                android:textStyle="bold" />
+                style="@style/TextAppearance.Title" />
 
             <ImageView
                 android:id="@+id/settingsIcon"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -105,6 +105,14 @@
         <item name="android:fontFamily">sans-serif</item>
     </style>
 
+    <!-- Button style for Quick Math answer options -->
+    <style name="Button.Answer" parent="Widget.MaterialComponents.Button">
+        <item name="backgroundTint">@color/button_background</item>
+        <item name="android:padding">16dp</item>
+        <item name="android:textColor">@color/text_primary</item>
+        <item name="android:textSize">24sp</item>
+    </style>
+
     <style name="TextAppearance.Settings" parent="TextAppearance.MaterialComponents.Subtitle1">
         <item name="android:textColor">@color/settings_text</item>
         <item name="android:textSize">24sp</item>


### PR DESCRIPTION
## Summary
- add `Button.Answer` style
- use `Button.Answer` for quick math answer buttons
- reuse `TextAppearance.Title` for screen titles

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851e742cebc83328b598b8b6a23485c