### PR TITLE
Add animation preference toggle

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -60,6 +60,7 @@ public class ResultActivity extends AppCompatActivity {
     private UserRepository userRepository;
     private FirebaseUser firebaseUser;
     private GameAnalytics analytics;
+    private boolean animationsEnabled;
     private int finalScore;
     private String finalGameType;
 
@@ -74,6 +75,7 @@ public class ResultActivity extends AppCompatActivity {
         initializeViews();
 
         prefs = getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
+        animationsEnabled = prefs.getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
         userRepository = new UserRepository(this);
         firebaseUser = FirebaseService.getInstance().getCurrentUser();
 
@@ -220,7 +222,10 @@ public class ResultActivity extends AppCompatActivity {
     }
 
     private void animateHeader() {
-        // Fade headerText in over 400ms
+        if (!animationsEnabled) {
+            headerText.setAlpha(1f);
+            return;
+        }
         AnimationUtils.fadeIn(headerText, 400);
     }
 
@@ -233,6 +238,20 @@ public class ResultActivity extends AppCompatActivity {
             final boolean willSyncRemote,
             final int wordsFound
     ) {
+        if (!animationsEnabled) {
+            scoreValue.setText(String.valueOf(finalScore));
+            totalWordText.setText(String.valueOf(wordsFound));
+            totalXPValue.setText(String.valueOf(finalTotalXp));
+            streakText.setText("🔥 " + finalStreak + " Day Streak");
+            streakText.setAlpha(1f);
+            if (isNewPb) {
+                newHighScoreText.setVisibility(View.VISIBLE);
+                newHighScoreText.setAlpha(1f);
+            }
+            if (xpGained > 0) SoundManager.getInstance(ResultActivity.this).playSuccess();
+            playContainer.setAlpha(1f);
+            return;
+        }
         // 1) Score count‐up
         ValueAnimator scoreAnim = ValueAnimator.ofInt(0, finalScore);
         scoreAnim.setDuration(600);
@@ -299,6 +318,11 @@ public class ResultActivity extends AppCompatActivity {
     }
 
     private void animateNewHighScoreBanner() {
+        if (!animationsEnabled) {
+            newHighScoreText.setVisibility(View.VISIBLE);
+            newHighScoreText.setAlpha(1f);
+            return;
+        }
         // 1) Pulse the "New High Score!" text
         newHighScoreText.setAlpha(0f);
         newHighScoreText.setScaleX(0.5f);
@@ -316,6 +340,11 @@ public class ResultActivity extends AppCompatActivity {
     }
 
     private void showEncouragement(String message) {
+        if (!animationsEnabled) {
+            encouragementText.setText(message.toUpperCase());
+            encouragementText.setAlpha(1f);
+            return;
+        }
         // Apply glow shader
         Shader myShader = new LinearGradient(
                 0, 100, 0, 100,

--- a/app/src/main/java/com/gigamind/cognify/ui/SplashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/SplashActivity.java
@@ -31,13 +31,14 @@ public class SplashActivity extends AppCompatActivity {
 
         // Disable heavy animations on low memory devices
         ActivityManager am = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
-        if (am != null && am.isLowRamDevice()) {
+        SharedPreferences prefs = getSharedPreferences(Constants.PREF_APP, MODE_PRIVATE);
+        boolean animationsEnabled = prefs.getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
+        if (!animationsEnabled || (am != null && am.isLowRamDevice())) {
             binding.splashAnimation.cancelAnimation();
             binding.splashAnimation.setVisibility(View.GONE);
         }
 
         // Check if first time launch
-        SharedPreferences prefs = getSharedPreferences(Constants.PREF_APP, MODE_PRIVATE);
         boolean isFirstLaunch = prefs.getBoolean(Constants.PREF_IS_FIRST_LAUNCH, true);
 
         // Deep link handling for challenge

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -212,7 +212,9 @@ public class HomeFragment extends Fragment {
      */
     private void setupClickListeners() {
         View.OnClickListener animatedClickListener = v -> {
-            v.startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.button_bounce));
+            if (areAnimationsEnabled()) {
+                v.startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.button_bounce));
+            }
             handleGameLaunch(v);
         };
 
@@ -248,6 +250,11 @@ public class HomeFragment extends Fragment {
                     .format(calendar.getTime());
             prefs.edit().putBoolean(Constants.PREF_DAILY_COMPLETED_PREFIX + todayKey, true).apply();
         }
+    }
+
+    private boolean areAnimationsEnabled() {
+        return requireContext().getSharedPreferences(Constants.PREF_APP, MODE_PRIVATE)
+                .getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
     }
 
     @Override

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -138,7 +138,9 @@ public class WordDashFragment extends Fragment {
      */
     private void setupClickListeners() {
         View.OnClickListener animatedClickListener = v -> {
-            v.startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.button_bounce));
+            if (areAnimationsEnabled()) {
+                v.startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.button_bounce));
+            }
             if (!tutorialHelper.isTutorialCompleted()) {
                 String msg = getString(R.string.play_tip);
                 Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_SHORT).show();
@@ -178,6 +180,11 @@ public class WordDashFragment extends Fragment {
                     .format(calendar.getTime());
             prefs.edit().putBoolean(Constants.PREF_DAILY_COMPLETED_PREFIX + todayKey, true).apply();
         }
+    }
+
+    private boolean areAnimationsEnabled() {
+        return requireContext().getSharedPreferences(Constants.PREF_APP, MODE_PRIVATE)
+                .getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
     }
 
     @Override

--- a/app/src/main/java/com/gigamind/cognify/util/AnimationUtils.java
+++ b/app/src/main/java/com/gigamind/cognify/util/AnimationUtils.java
@@ -1,6 +1,8 @@
 // file: com/gigamind/cognify/util/AnimationUtils.java
 package com.gigamind.cognify.util;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.view.View;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.ScaleAnimation;
@@ -15,6 +17,7 @@ public final class AnimationUtils {
      * Scale a view up to `scale` then back down to 1f, all in `duration` ms.
      */
     public static void pulse(View view, float scale, long duration) {
+        if (!isAnimationsEnabled(view.getContext())) return;
         view.animate()
                 .scaleX(scale)
                 .scaleY(scale)
@@ -36,6 +39,7 @@ public final class AnimationUtils {
      * @param distancePx How far (in pixels) to translate the view.
      */
     public static void shake(View view, float distancePx) {
+        if (!isAnimationsEnabled(view.getContext())) return;
         view.animate()
                 .translationX(distancePx)
                 .setDuration(50)
@@ -64,6 +68,11 @@ public final class AnimationUtils {
      * Fade a view in over `duration` ms. Makes the view visible.
      */
     public static void fadeIn(View view, long duration) {
+        if (!isAnimationsEnabled(view.getContext())) {
+            view.setAlpha(1f);
+            view.setVisibility(View.VISIBLE);
+            return;
+        }
         view.setAlpha(0f);
         view.setVisibility(View.VISIBLE);
         view.animate()
@@ -77,6 +86,11 @@ public final class AnimationUtils {
      * Fade a view out over `duration` ms, then set GONE.
      */
     public static void fadeOut(View view, long duration) {
+        if (!isAnimationsEnabled(view.getContext())) {
+            view.setAlpha(0f);
+            view.setVisibility(View.GONE);
+            return;
+        }
         view.animate()
                 .alpha(0f)
                 .setDuration(duration)
@@ -90,6 +104,11 @@ public final class AnimationUtils {
      * (Useful if you want to chain animations in sequence.)
      */
     public static void fadeInWithDelay(View view, long delayMs, long duration) {
+        if (!isAnimationsEnabled(view.getContext())) {
+            view.setAlpha(1f);
+            view.setVisibility(View.VISIBLE);
+            return;
+        }
         view.setAlpha(0f);
         view.setVisibility(View.VISIBLE);
         view.animate()
@@ -98,5 +117,11 @@ public final class AnimationUtils {
                 .setDuration(duration)
                 .setInterpolator(new AccelerateDecelerateInterpolator())
                 .start();
+    }
+
+    private static boolean isAnimationsEnabled(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(
+                Constants.PREF_APP, Context.MODE_PRIVATE);
+        return prefs.getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
     }
 }


### PR DESCRIPTION
## Summary
- respect animation toggle in `AnimationUtils`
- guard bounce animations in HomeFragment and WordDashFragment
- skip splash and result screen animations when disabled

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851ea92653483329aa9275556d02eaf