### PR TITLE
Add new audio cues

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -148,6 +148,10 @@ public class ResultActivity extends AppCompatActivity {
         String uid = (firebaseUser != null) ? firebaseUser.getUid() : null;
         StreakNotificationScheduler.scheduleFromSharedPrefs(uid, this);
 
+        if (newStreak > 0 && newStreak != oldStreak && newStreak % 5 == 0) {
+            SoundManager.getInstance(this).playMilestone();
+        }
+
         // (10) Animate everything in sequence:
         animateHeader();
         animateNumbersSequentially(

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -22,6 +22,7 @@ import com.gigamind.cognify.ui.OnboardingActivity;
 import com.gigamind.cognify.util.Constants;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.gigamind.cognify.data.firebase.FirebaseService;
+import com.gigamind.cognify.util.SoundManager;
 import com.google.android.gms.auth.api.signin.GoogleSignIn;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.android.gms.auth.api.signin.GoogleSignInClient;
@@ -80,14 +81,20 @@ public class SettingsFragment extends Fragment {
         }
 
         // Set up listeners
-        binding.soundEffectsSwitch.setOnCheckedChangeListener((buttonView, isChecked) ->
-                prefs.edit().putBoolean(KEY_SOUND_ENABLED, isChecked).apply());
+        binding.soundEffectsSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                prefs.edit().putBoolean(KEY_SOUND_ENABLED, isChecked).apply();
+                SoundManager.getInstance(requireContext()).playToggle();
+        });
 
-        binding.hapticsSwitch.setOnCheckedChangeListener((buttonView, isChecked) ->
-                prefs.edit().putBoolean(KEY_HAPTICS_ENABLED, isChecked).apply());
+        binding.hapticsSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                prefs.edit().putBoolean(KEY_HAPTICS_ENABLED, isChecked).apply();
+                SoundManager.getInstance(requireContext()).playToggle();
+        });
 
-        binding.animationsSwitch.setOnCheckedChangeListener((buttonView, isChecked) ->
-                prefs.edit().putBoolean(KEY_ANIMATIONS_ENABLED, isChecked).apply());
+        binding.animationsSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                prefs.edit().putBoolean(KEY_ANIMATIONS_ENABLED, isChecked).apply();
+                SoundManager.getInstance(requireContext()).playToggle();
+        });
 
         binding.darkModeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
             prefs.edit().putBoolean(KEY_DARK_MODE_ENABLED, isChecked).apply();
@@ -96,6 +103,7 @@ public class SettingsFragment extends Fragment {
             } else {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
             }
+            SoundManager.getInstance(requireContext()).playToggle();
         });
     }
 

--- a/app/src/main/java/com/gigamind/cognify/util/SoundManager.java
+++ b/app/src/main/java/com/gigamind/cognify/util/SoundManager.java
@@ -24,6 +24,9 @@ public class SoundManager {
     private final int correctSoundId;
     private final int wrongSoundId;
     private final int heartbeatSoundId;
+    // Reuse existing sounds for additional cues
+    private final int toggleSoundId;
+    private final int milestoneSoundId;
     private final Context context;
     private final Vibrator vibrator;
 
@@ -60,6 +63,10 @@ public class SoundManager {
 
         heartbeatSoundId = soundPool.load(context, R.raw.heartbeat, 1);
         loadedMap.put(heartbeatSoundId, false);
+
+        // For toggles and milestone cues we simply reuse existing files
+        toggleSoundId = buttonSoundId;
+        milestoneSoundId = successSoundId;
 
         soundPool.setOnLoadCompleteListener((sp, sampleId, status) -> {
             if (status == 0) {
@@ -100,6 +107,16 @@ public class SoundManager {
 
     public void playHeartbeat() {
         playSound(heartbeatSoundId);
+    }
+
+    /** Plays a short click sound for toggle switches */
+    public void playToggle() {
+        playSound(toggleSoundId);
+    }
+
+    /** Plays a rewarding sound for streak milestones */
+    public void playMilestone() {
+        playSound(milestoneSoundId);
     }
 
     private void playSound(int soundId) {


### PR DESCRIPTION
## Summary
- handle toggle switches with new `SoundManager.playToggle`
- add milestone sound when a streak hits a multiple of 5
- extend `SoundManager` with toggle and milestone helpers

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851eb45bbe08332968dda798f34f5be