### PR TITLE
Refactor animation utilities

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -313,17 +313,11 @@ public class WordDashActivity extends AppCompatActivity {
         if (hapticsEnabled) {
             scoreText.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
         }
-        scoreText.animate()
-                .scaleX(1.3f)
-                .scaleY(1.3f)
-                .setDuration(GameConfig.SCORE_ANIMATION_DURATION_MS)
-                .withEndAction(() ->
-                        scoreText.animate()
-                                .scaleX(1f)
-                                .scaleY(1f)
-                                .setDuration(GameConfig.SCORE_ANIMATION_DURATION_MS)
-                                .start()
-                ).start();
+        com.gigamind.cognify.util.AnimationUtils.pulse(
+                scoreText,
+                1.3f,
+                GameConfig.SCORE_ANIMATION_DURATION_MS
+        );
     }
 
     private void showError(String message) {

--- a/app/src/main/java/com/gigamind/cognify/util/AnimationUtils.java
+++ b/app/src/main/java/com/gigamind/cognify/util/AnimationUtils.java
@@ -1,127 +1,34 @@
 // file: com/gigamind/cognify/util/AnimationUtils.java
 package com.gigamind.cognify.util;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.view.View;
-import android.view.animation.AccelerateDecelerateInterpolator;
-import android.view.animation.ScaleAnimation;
-import android.widget.GridLayout;
 
 public final class AnimationUtils {
     private AnimationUtils() {
         throw new AssertionError("No instances allowed");
     }
 
-    /**
-     * Scale a view up to `scale` then back down to 1f, all in `duration` ms.
-     */
     public static void pulse(View view, float scale, long duration) {
-        if (!isAnimationsEnabled(view.getContext())) return;
-        view.animate()
-                .scaleX(scale)
-                .scaleY(scale)
-                .setDuration(duration)
-                .setInterpolator(new AccelerateDecelerateInterpolator())
-                .withEndAction(() -> view.animate()
-                        .scaleX(1f)
-                        .scaleY(1f)
-                        .setDuration(duration)
-                        .setInterpolator(new AccelerateDecelerateInterpolator())
-                        .start()
-                )
-                .start();
+        AnimatorProvider.get().pulse(view, scale, duration);
     }
 
-    /**
-     * Shake a view left → right → back to center in quick succession.
-     * @param view The target view to shake.
-     * @param distancePx How far (in pixels) to translate the view.
-     */
     public static void shake(View view, float distancePx) {
-        if (!isAnimationsEnabled(view.getContext())) return;
-        view.animate()
-                .translationX(distancePx)
-                .setDuration(50)
-                .setInterpolator(new AccelerateDecelerateInterpolator())
-                .withEndAction(() -> view.animate()
-                        .translationX(-distancePx)
-                        .setDuration(50)
-                        .setInterpolator(new AccelerateDecelerateInterpolator())
-                        .withEndAction(() -> view.animate()
-                                .translationX(0)
-                                .setDuration(50)
-                                .setInterpolator(new AccelerateDecelerateInterpolator())
-                                .start()
-                        )
-                        .start()
-                )
-                .start();
+        AnimatorProvider.get().shake(view, distancePx);
     }
 
-    /** Convenience overload using a default shake distance of 10px. */
     public static void shake(View view) {
-        shake(view, 10f);
+        AnimatorProvider.get().shake(view);
     }
 
-    /**
-     * Fade a view in over `duration` ms. Makes the view visible.
-     */
     public static void fadeIn(View view, long duration) {
-        if (!isAnimationsEnabled(view.getContext())) {
-            view.setAlpha(1f);
-            view.setVisibility(View.VISIBLE);
-            return;
-        }
-        view.setAlpha(0f);
-        view.setVisibility(View.VISIBLE);
-        view.animate()
-                .alpha(1f)
-                .setDuration(duration)
-                .setInterpolator(new AccelerateDecelerateInterpolator())
-                .start();
+        AnimatorProvider.get().fadeIn(view, duration);
     }
 
-    /**
-     * Fade a view out over `duration` ms, then set GONE.
-     */
     public static void fadeOut(View view, long duration) {
-        if (!isAnimationsEnabled(view.getContext())) {
-            view.setAlpha(0f);
-            view.setVisibility(View.GONE);
-            return;
-        }
-        view.animate()
-                .alpha(0f)
-                .setDuration(duration)
-                .setInterpolator(new AccelerateDecelerateInterpolator())
-                .withEndAction(() -> view.setVisibility(View.GONE))
-                .start();
+        AnimatorProvider.get().fadeOut(view, duration);
     }
 
-    /**
-     * Fade a view in **after** a given delay.
-     * (Useful if you want to chain animations in sequence.)
-     */
     public static void fadeInWithDelay(View view, long delayMs, long duration) {
-        if (!isAnimationsEnabled(view.getContext())) {
-            view.setAlpha(1f);
-            view.setVisibility(View.VISIBLE);
-            return;
-        }
-        view.setAlpha(0f);
-        view.setVisibility(View.VISIBLE);
-        view.animate()
-                .alpha(1f)
-                .setStartDelay(delayMs)
-                .setDuration(duration)
-                .setInterpolator(new AccelerateDecelerateInterpolator())
-                .start();
-    }
-
-    private static boolean isAnimationsEnabled(Context context) {
-        SharedPreferences prefs = context.getSharedPreferences(
-                Constants.PREF_APP, Context.MODE_PRIVATE);
-        return prefs.getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
+        AnimatorProvider.get().fadeInWithDelay(view, delayMs, duration);
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/util/AnimatorProvider.java
+++ b/app/src/main/java/com/gigamind/cognify/util/AnimatorProvider.java
@@ -1,0 +1,26 @@
+package com.gigamind.cognify.util;
+
+/**
+ * Simple service locator for {@link ViewAnimator} instances. Allows swapping
+ * implementations for testing or to globally disable animations.
+ */
+public final class AnimatorProvider {
+    private static ViewAnimator instance = new DefaultViewAnimator();
+
+    private AnimatorProvider() {
+        // no instances
+    }
+
+    /** Returns the current {@link ViewAnimator} implementation. */
+    public static ViewAnimator get() {
+        return instance;
+    }
+
+    /**
+     * Replaces the current animator implementation. Passing {@code null}
+     * resets to the default animator.
+     */
+    public static void set(ViewAnimator animator) {
+        instance = (animator != null) ? animator : new DefaultViewAnimator();
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/util/DefaultViewAnimator.java
+++ b/app/src/main/java/com/gigamind/cognify/util/DefaultViewAnimator.java
@@ -1,0 +1,109 @@
+package com.gigamind.cognify.util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.view.View;
+import android.view.animation.AccelerateDecelerateInterpolator;
+
+/**
+ * Default implementation of {@link ViewAnimator} that plays actual animations
+ * using ViewPropertyAnimator APIs.
+ */
+public class DefaultViewAnimator implements ViewAnimator {
+
+    private boolean animationsEnabled(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(
+                Constants.PREF_APP, Context.MODE_PRIVATE);
+        return prefs.getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
+    }
+
+    @Override
+    public void pulse(View view, float scale, long duration) {
+        if (!animationsEnabled(view.getContext())) return;
+        view.animate()
+                .scaleX(scale)
+                .scaleY(scale)
+                .setDuration(duration)
+                .setInterpolator(new AccelerateDecelerateInterpolator())
+                .withEndAction(() -> view.animate()
+                        .scaleX(1f)
+                        .scaleY(1f)
+                        .setDuration(duration)
+                        .setInterpolator(new AccelerateDecelerateInterpolator())
+                        .start())
+                .start();
+    }
+
+    @Override
+    public void shake(View view, float distancePx) {
+        if (!animationsEnabled(view.getContext())) return;
+        view.animate()
+                .translationX(distancePx)
+                .setDuration(50)
+                .setInterpolator(new AccelerateDecelerateInterpolator())
+                .withEndAction(() -> view.animate()
+                        .translationX(-distancePx)
+                        .setDuration(50)
+                        .setInterpolator(new AccelerateDecelerateInterpolator())
+                        .withEndAction(() -> view.animate()
+                                .translationX(0)
+                                .setDuration(50)
+                                .setInterpolator(new AccelerateDecelerateInterpolator())
+                                .start())
+                        .start())
+                .start();
+    }
+
+    @Override
+    public void shake(View view) {
+        shake(view, 10f);
+    }
+
+    @Override
+    public void fadeIn(View view, long duration) {
+        if (!animationsEnabled(view.getContext())) {
+            view.setAlpha(1f);
+            view.setVisibility(View.VISIBLE);
+            return;
+        }
+        view.setAlpha(0f);
+        view.setVisibility(View.VISIBLE);
+        view.animate()
+                .alpha(1f)
+                .setDuration(duration)
+                .setInterpolator(new AccelerateDecelerateInterpolator())
+                .start();
+    }
+
+    @Override
+    public void fadeOut(View view, long duration) {
+        if (!animationsEnabled(view.getContext())) {
+            view.setAlpha(0f);
+            view.setVisibility(View.GONE);
+            return;
+        }
+        view.animate()
+                .alpha(0f)
+                .setDuration(duration)
+                .setInterpolator(new AccelerateDecelerateInterpolator())
+                .withEndAction(() -> view.setVisibility(View.GONE))
+                .start();
+    }
+
+    @Override
+    public void fadeInWithDelay(View view, long delayMs, long duration) {
+        if (!animationsEnabled(view.getContext())) {
+            view.setAlpha(1f);
+            view.setVisibility(View.VISIBLE);
+            return;
+        }
+        view.setAlpha(0f);
+        view.setVisibility(View.VISIBLE);
+        view.animate()
+                .alpha(1f)
+                .setStartDelay(delayMs)
+                .setDuration(duration)
+                .setInterpolator(new AccelerateDecelerateInterpolator())
+                .start();
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/util/ViewAnimator.java
+++ b/app/src/main/java/com/gigamind/cognify/util/ViewAnimator.java
@@ -1,0 +1,16 @@
+package com.gigamind.cognify.util;
+
+import android.view.View;
+
+/**
+ * Strategy interface defining basic view animations. Implementations can
+ * provide different animation behaviors or no-ops for testing.
+ */
+public interface ViewAnimator {
+    void pulse(View view, float scale, long duration);
+    void shake(View view, float distancePx);
+    void shake(View view); // convenience
+    void fadeIn(View view, long duration);
+    void fadeOut(View view, long duration);
+    void fadeInWithDelay(View view, long delayMs, long duration);
+}


### PR DESCRIPTION
## Summary
- introduce `ViewAnimator` interface with default implementation
- add `AnimatorProvider` service locator for easy swapping of animation behavior
- delegate existing `AnimationUtils` calls to the new strategy
- reuse `pulse` helper in `WordDashActivity` to remove duplicate animation code

## Testing
- `./gradlew help` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851eeede1488332a915036fead82dcb