### PR TITLE
Refactor animation handling using provider pattern

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
+++ b/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
@@ -43,6 +43,7 @@ public class CognifyApplication extends Application {
         boolean darkMode = themePrefs.getBoolean(Constants.PREF_DARK_MODE_ENABLED, false);
         AppCompatDelegate.setDefaultNightMode(darkMode ?
                 AppCompatDelegate.MODE_NIGHT_YES : AppCompatDelegate.MODE_NIGHT_NO);
+        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(this);
 
         Thread.UncaughtExceptionHandler previousHandler = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler((t, e) -> {

--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -60,7 +60,6 @@ public class ResultActivity extends AppCompatActivity {
     private UserRepository userRepository;
     private FirebaseUser firebaseUser;
     private GameAnalytics analytics;
-    private boolean animationsEnabled;
     private int finalScore;
     private String finalGameType;
 
@@ -75,7 +74,7 @@ public class ResultActivity extends AppCompatActivity {
         initializeViews();
 
         prefs = getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
-        animationsEnabled = prefs.getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
+        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(this);
         userRepository = new UserRepository(this);
         firebaseUser = FirebaseService.getInstance().getCurrentUser();
 
@@ -226,7 +225,7 @@ public class ResultActivity extends AppCompatActivity {
     }
 
     private void animateHeader() {
-        if (!animationsEnabled) {
+        if (!com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled()) {
             headerText.setAlpha(1f);
             return;
         }
@@ -242,7 +241,7 @@ public class ResultActivity extends AppCompatActivity {
             final boolean willSyncRemote,
             final int wordsFound
     ) {
-        if (!animationsEnabled) {
+        if (!com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled()) {
             scoreValue.setText(String.valueOf(finalScore));
             totalWordText.setText(String.valueOf(wordsFound));
             totalXPValue.setText(String.valueOf(finalTotalXp));
@@ -322,7 +321,7 @@ public class ResultActivity extends AppCompatActivity {
     }
 
     private void animateNewHighScoreBanner() {
-        if (!animationsEnabled) {
+        if (!com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled()) {
             newHighScoreText.setVisibility(View.VISIBLE);
             newHighScoreText.setAlpha(1f);
             return;
@@ -344,7 +343,7 @@ public class ResultActivity extends AppCompatActivity {
     }
 
     private void showEncouragement(String message) {
-        if (!animationsEnabled) {
+        if (!com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled()) {
             encouragementText.setText(message.toUpperCase());
             encouragementText.setAlpha(1f);
             return;

--- a/app/src/main/java/com/gigamind/cognify/ui/SplashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/SplashActivity.java
@@ -32,7 +32,8 @@ public class SplashActivity extends AppCompatActivity {
         // Disable heavy animations on low memory devices
         ActivityManager am = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
         SharedPreferences prefs = getSharedPreferences(Constants.PREF_APP, MODE_PRIVATE);
-        boolean animationsEnabled = prefs.getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
+        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(this);
+        boolean animationsEnabled = com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled();
         if (!animationsEnabled || (am != null && am.isLowRamDevice())) {
             binding.splashAnimation.cancelAnimation();
             binding.splashAnimation.setVisibility(View.GONE);

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -86,6 +86,7 @@ public class HomeFragment extends Fragment {
 
         // Initialize SharedPreferences and UserRepository
         prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
+        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(requireContext());
         userRepository = new UserRepository(requireContext());
 
         // Check signed-in user
@@ -253,8 +254,7 @@ public class HomeFragment extends Fragment {
     }
 
     private boolean areAnimationsEnabled() {
-        return requireContext().getSharedPreferences(Constants.PREF_APP, MODE_PRIVATE)
-                .getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
+        return com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled();
     }
 
     @Override

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -58,6 +58,7 @@ public class SettingsFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         prefs = requireActivity().getSharedPreferences(Constants.PREF_APP, 0);
+        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(requireContext());
         GoogleSignInOptions gso = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
                 .requestIdToken(getString(R.string.default_web_client_id))
                 .requestEmail()
@@ -93,6 +94,7 @@ public class SettingsFragment extends Fragment {
 
         binding.animationsSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
                 prefs.edit().putBoolean(KEY_ANIMATIONS_ENABLED, isChecked).apply();
+                com.gigamind.cognify.util.AnimatorProvider.setAnimationsEnabled(isChecked);
                 SoundManager.getInstance(requireContext()).playToggle();
         });
 

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -76,6 +76,7 @@ public class WordDashFragment extends Fragment {
 
         // Initialize SharedPreferences, repositories and helpers
         prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
+        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(requireContext());
         userRepository = new UserRepository(requireContext());
         tutorialHelper = new TutorialHelper(requireContext());
 
@@ -183,8 +184,7 @@ public class WordDashFragment extends Fragment {
     }
 
     private boolean areAnimationsEnabled() {
-        return requireContext().getSharedPreferences(Constants.PREF_APP, MODE_PRIVATE)
-                .getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
+        return com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled();
     }
 
     @Override

--- a/app/src/main/java/com/gigamind/cognify/util/AnimatorProvider.java
+++ b/app/src/main/java/com/gigamind/cognify/util/AnimatorProvider.java
@@ -5,7 +5,9 @@ package com.gigamind.cognify.util;
  * implementations for testing or to globally disable animations.
  */
 public final class AnimatorProvider {
-    private static ViewAnimator instance = new DefaultViewAnimator();
+    private static ViewAnimator defaultAnimator = new DefaultViewAnimator();
+    private static final ViewAnimator NO_OP_ANIMATOR = new NoOpViewAnimator();
+    private static boolean animationsEnabled = true;
 
     private AnimatorProvider() {
         // no instances
@@ -13,7 +15,7 @@ public final class AnimatorProvider {
 
     /** Returns the current {@link ViewAnimator} implementation. */
     public static ViewAnimator get() {
-        return instance;
+        return animationsEnabled ? defaultAnimator : NO_OP_ANIMATOR;
     }
 
     /**
@@ -21,6 +23,23 @@ public final class AnimatorProvider {
      * resets to the default animator.
      */
     public static void set(ViewAnimator animator) {
-        instance = (animator != null) ? animator : new DefaultViewAnimator();
+        defaultAnimator = (animator != null) ? animator : new DefaultViewAnimator();
+    }
+
+    /** Enable or disable animations globally. */
+    public static void setAnimationsEnabled(boolean enabled) {
+        animationsEnabled = enabled;
+    }
+
+    /** Returns whether animations are currently enabled. */
+    public static boolean isAnimationsEnabled() {
+        return animationsEnabled;
+    }
+
+    /** Updates the animation state based on shared preferences. */
+    public static void updateFromPreferences(android.content.Context context) {
+        android.content.SharedPreferences prefs = context.getSharedPreferences(
+                Constants.PREF_APP, android.content.Context.MODE_PRIVATE);
+        setAnimationsEnabled(prefs.getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true));
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/util/DefaultViewAnimator.java
+++ b/app/src/main/java/com/gigamind/cognify/util/DefaultViewAnimator.java
@@ -1,7 +1,5 @@
 package com.gigamind.cognify.util;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.view.View;
 import android.view.animation.AccelerateDecelerateInterpolator;
 
@@ -11,15 +9,9 @@ import android.view.animation.AccelerateDecelerateInterpolator;
  */
 public class DefaultViewAnimator implements ViewAnimator {
 
-    private boolean animationsEnabled(Context context) {
-        SharedPreferences prefs = context.getSharedPreferences(
-                Constants.PREF_APP, Context.MODE_PRIVATE);
-        return prefs.getBoolean(Constants.PREF_ANIMATIONS_ENABLED, true);
-    }
 
     @Override
     public void pulse(View view, float scale, long duration) {
-        if (!animationsEnabled(view.getContext())) return;
         view.animate()
                 .scaleX(scale)
                 .scaleY(scale)
@@ -36,7 +28,6 @@ public class DefaultViewAnimator implements ViewAnimator {
 
     @Override
     public void shake(View view, float distancePx) {
-        if (!animationsEnabled(view.getContext())) return;
         view.animate()
                 .translationX(distancePx)
                 .setDuration(50)
@@ -61,11 +52,6 @@ public class DefaultViewAnimator implements ViewAnimator {
 
     @Override
     public void fadeIn(View view, long duration) {
-        if (!animationsEnabled(view.getContext())) {
-            view.setAlpha(1f);
-            view.setVisibility(View.VISIBLE);
-            return;
-        }
         view.setAlpha(0f);
         view.setVisibility(View.VISIBLE);
         view.animate()
@@ -77,11 +63,6 @@ public class DefaultViewAnimator implements ViewAnimator {
 
     @Override
     public void fadeOut(View view, long duration) {
-        if (!animationsEnabled(view.getContext())) {
-            view.setAlpha(0f);
-            view.setVisibility(View.GONE);
-            return;
-        }
         view.animate()
                 .alpha(0f)
                 .setDuration(duration)
@@ -92,11 +73,6 @@ public class DefaultViewAnimator implements ViewAnimator {
 
     @Override
     public void fadeInWithDelay(View view, long delayMs, long duration) {
-        if (!animationsEnabled(view.getContext())) {
-            view.setAlpha(1f);
-            view.setVisibility(View.VISIBLE);
-            return;
-        }
         view.setAlpha(0f);
         view.setVisibility(View.VISIBLE);
         view.animate()

--- a/app/src/main/java/com/gigamind/cognify/util/NoOpViewAnimator.java
+++ b/app/src/main/java/com/gigamind/cognify/util/NoOpViewAnimator.java
@@ -1,0 +1,44 @@
+package com.gigamind.cognify.util;
+
+import android.view.View;
+
+/**
+ * Null object implementation of {@link ViewAnimator} used when animations are
+ * disabled. All methods simply update view properties to their final state
+ * without performing any animated transitions.
+ */
+public class NoOpViewAnimator implements ViewAnimator {
+
+    @Override
+    public void pulse(View view, float scale, long duration) {
+        // no-op
+    }
+
+    @Override
+    public void shake(View view, float distancePx) {
+        // no-op
+    }
+
+    @Override
+    public void shake(View view) {
+        // no-op
+    }
+
+    @Override
+    public void fadeIn(View view, long duration) {
+        view.setAlpha(1f);
+        view.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    public void fadeOut(View view, long duration) {
+        view.setAlpha(0f);
+        view.setVisibility(View.GONE);
+    }
+
+    @Override
+    public void fadeInWithDelay(View view, long delayMs, long duration) {
+        view.setAlpha(1f);
+        view.setVisibility(View.VISIBLE);
+    }
+}


### PR DESCRIPTION
## Summary
- add `NoOpViewAnimator` implementing a null object pattern
- refactor `AnimatorProvider` to toggle between default and no-op animators
- update `DefaultViewAnimator` to always run animations
- hook provider updates in application startup and various activities/fragments
- use provider in settings toggle

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851efdf16908332a1e5c332bd49824d