### PR TITLE
Implement strategy pattern for math scoring

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/engine/MathGameEngine.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/MathGameEngine.java
@@ -6,17 +6,25 @@ import java.util.List;
 import java.util.Random;
 
 import com.gigamind.cognify.util.GameConfig;
+import com.gigamind.cognify.engine.scoring.DefaultMathScoreStrategy;
+import com.gigamind.cognify.engine.scoring.MathScoreStrategy;
 
 public class MathGameEngine {
     private final Random random;
+    private final MathScoreStrategy scoreStrategy;
     private int currentAnswer;
     private String currentQuestion;
     private List<Integer> currentOptions;
     private int currentDifficulty;
 
     public MathGameEngine() {
+        this(new DefaultMathScoreStrategy());
+    }
+
+    public MathGameEngine(MathScoreStrategy strategy) {
         random = new Random();
         currentOptions = new ArrayList<>();
+        scoreStrategy = strategy != null ? strategy : new DefaultMathScoreStrategy();
     }
 
     public void generateQuestion() {
@@ -98,15 +106,7 @@ public class MathGameEngine {
     }
 
     public int getScore(boolean correct, long timeMs) {
-        if (!correct) {
-            return -5;
-        }
-        int base = GameConfig.BASE_SCORE * currentDifficulty;
-
-        long clamped = Math.min(timeMs, GameConfig.MAX_RESPONSE_TIME_MS);
-        double factor = 1.0 + (double) (GameConfig.MAX_RESPONSE_TIME_MS - clamped)
-                / GameConfig.MAX_RESPONSE_TIME_MS;
-        return (int) Math.round(base * factor);
+        return scoreStrategy.calculateScore(correct, timeMs, currentDifficulty);
     }
 
     public int getCurrentDifficulty() {

--- a/app/src/main/java/com/gigamind/cognify/engine/scoring/DefaultMathScoreStrategy.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/scoring/DefaultMathScoreStrategy.java
@@ -1,0 +1,26 @@
+package com.gigamind.cognify.engine.scoring;
+
+import com.gigamind.cognify.util.GameConfig;
+
+/**
+ * Default implementation of {@link MathScoreStrategy} mirroring the original
+ * scoring logic from {@code MathGameEngine}.
+ */
+public class DefaultMathScoreStrategy implements MathScoreStrategy {
+
+    @Override
+    public int calculateScore(boolean correct, long responseTimeMs, int difficulty) {
+        if (!correct) {
+            return -5;
+        }
+
+        int base = GameConfig.BASE_SCORE * difficulty;
+        long clamped = Math.min(responseTimeMs, GameConfig.MAX_RESPONSE_TIME_MS);
+        double factor = 1.0
+                + (double) (GameConfig.MAX_RESPONSE_TIME_MS - clamped)
+                / GameConfig.MAX_RESPONSE_TIME_MS;
+
+        return (int) Math.round(base * factor);
+    }
+}
+

--- a/app/src/main/java/com/gigamind/cognify/engine/scoring/MathScoreStrategy.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/scoring/MathScoreStrategy.java
@@ -1,0 +1,23 @@
+package com.gigamind.cognify.engine.scoring;
+
+/**
+ * Strategy interface for calculating scores in the math game.
+ *
+ * <p>Extracting this allows alternative scoring rules to be provided
+ * without modifying the {@code MathGameEngine}, following the
+ * <em>Open/Closed</em> principle from Clean Code and Code Complete.</p>
+ */
+public interface MathScoreStrategy {
+
+    /**
+     * Calculates a score given whether the answer was correct, the response
+     * time in milliseconds and the difficulty level of the question.
+     *
+     * @param correct        whether the player's answer was correct
+     * @param responseTimeMs how long it took the player to answer
+     * @param difficulty     the difficulty level of the current question
+     * @return the score to award (or deduct)
+     */
+    int calculateScore(boolean correct, long responseTimeMs, int difficulty);
+}
+


### PR DESCRIPTION
## Summary
- introduce `MathScoreStrategy` and `DefaultMathScoreStrategy`
- refactor `MathGameEngine` to use the new strategy

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851f25ba8c48332a75a53c250ff173b