### PR TITLE
Refactor avatar loading logic

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -12,10 +12,6 @@ import android.view.animation.AnimationUtils;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import de.hdodenhof.circleimageview.CircleImageView;
-import android.util.Base64;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import com.bumptech.glide.Glide;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -28,6 +24,7 @@ import com.gigamind.cognify.databinding.FragmentHomeBinding;
 import com.gigamind.cognify.ui.QuickMathActivity;
 import com.gigamind.cognify.ui.WordDashActivity;
 import com.gigamind.cognify.util.Constants;
+import com.gigamind.cognify.util.AvatarLoader;
 import com.gigamind.cognify.model.Quest;
 import com.gigamind.cognify.util.QuestManager;
 import android.graphics.Color;
@@ -153,16 +150,7 @@ public class HomeFragment extends Fragment {
     }
 
     private void loadAvatar() {
-        String stored = userRepository.getProfilePicture();
-        if (stored != null && !stored.isEmpty()) {
-            if (stored.startsWith("http")) {
-                Glide.with(this).load(stored).into(currentUserAvatar);
-            } else {
-                byte[] bytes = Base64.decode(stored, Base64.DEFAULT);
-                Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
-                currentUserAvatar.setImageBitmap(bmp);
-            }
-        }
+        AvatarLoader.load(userRepository, currentUserAvatar);
     }
 
     /**

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -11,10 +11,6 @@ import android.widget.Button;
 import android.widget.ImageView;
 import de.hdodenhof.circleimageview.CircleImageView;
 import android.widget.TextView;
-import android.util.Base64;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import com.bumptech.glide.Glide;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -24,6 +20,7 @@ import com.gigamind.cognify.R;
 import com.gigamind.cognify.data.repository.UserRepository;
 import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.gigamind.cognify.util.Constants;
+import com.gigamind.cognify.util.AvatarLoader;
 import com.gigamind.cognify.util.UserFields;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.snackbar.Snackbar;
@@ -158,13 +155,7 @@ public class ProfileFragment extends Fragment {
                             String rate = total > 0 ? (100 * wins / total) + "%" : "0%";
                             winRateValue.setText(rate);
                             if (encodedPic != null && !encodedPic.isEmpty()) {
-                                if (encodedPic.startsWith("http")) {
-                                    Glide.with(ProfileFragment.this).load(encodedPic).into(profileAvatar);
-                                } else {
-                                    byte[] bytes = Base64.decode(encodedPic, Base64.DEFAULT);
-                                    Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
-                                    profileAvatar.setImageBitmap(bmp);
-                                }
+                                AvatarLoader.load(userRepository, profileAvatar);
                             }
                         });
                     }
@@ -230,16 +221,7 @@ public class ProfileFragment extends Fragment {
     }
 
     private void loadAvatar() {
-        String stored = userRepository.getProfilePicture();
-        if (stored != null && !stored.isEmpty()) {
-            if (stored.startsWith("http")) {
-                Glide.with(this).load(stored).into(profileAvatar);
-            } else {
-                byte[] bytes = Base64.decode(stored, Base64.DEFAULT);
-                Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
-                profileAvatar.setImageBitmap(bmp);
-            }
-        }
+        AvatarLoader.load(userRepository, profileAvatar);
     }
 
     @Override

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -9,13 +9,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AnimationUtils;
-import android.widget.ImageView;
 import de.hdodenhof.circleimageview.CircleImageView;
 import android.widget.TextView;
-import android.util.Base64;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import com.bumptech.glide.Glide;
 import com.google.android.material.snackbar.Snackbar;
 
 import androidx.annotation.NonNull;
@@ -28,6 +23,7 @@ import com.gigamind.cognify.databinding.FragmentWordDashBinding;
 import com.gigamind.cognify.ui.QuickMathActivity;
 import com.gigamind.cognify.ui.WordDashActivity;
 import com.gigamind.cognify.util.Constants;
+import com.gigamind.cognify.util.AvatarLoader;
 import com.gigamind.cognify.util.TutorialHelper;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.button.MaterialButton;
@@ -121,16 +117,7 @@ public class WordDashFragment extends Fragment {
     }
 
     private void loadAvatar() {
-        String stored = userRepository.getProfilePicture();
-        if (stored != null && !stored.isEmpty()) {
-            if (stored.startsWith("http")) {
-                Glide.with(this).load(stored).into(userProfileButton);
-            } else {
-                byte[] bytes = Base64.decode(stored, Base64.DEFAULT);
-                Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
-                userProfileButton.setImageBitmap(bmp);
-            }
-        }
+        AvatarLoader.load(userRepository, userProfileButton);
     }
 
     /**

--- a/app/src/main/java/com/gigamind/cognify/util/AvatarLoader.java
+++ b/app/src/main/java/com/gigamind/cognify/util/AvatarLoader.java
@@ -1,0 +1,37 @@
+package com.gigamind.cognify.util;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Base64;
+import android.widget.ImageView;
+
+import com.bumptech.glide.Glide;
+import com.gigamind.cognify.data.repository.UserRepository;
+
+/**
+ * Utility class to load a user avatar from the {@link UserRepository} into an
+ * {@link ImageView}. This centralizes the logic of decoding base64 images or
+ * loading remote URLs so fragments do not duplicate the same code.
+ */
+public final class AvatarLoader {
+    private AvatarLoader() { }
+
+    /**
+     * Loads the profile picture stored in the repository into the provided view.
+     * If no avatar is stored, the view is left unchanged.
+     */
+    public static void load(UserRepository repository, ImageView target) {
+        if (repository == null || target == null) return;
+        String stored = repository.getProfilePicture();
+        if (stored == null || stored.isEmpty()) return;
+
+        if (stored.startsWith("http")) {
+            Glide.with(target.getContext()).load(stored).into(target);
+        } else {
+            byte[] bytes = Base64.decode(stored, Base64.DEFAULT);
+            Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+            target.setImageBitmap(bmp);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- consolidate repeated avatar decoding and loading into `AvatarLoader`
- use new utility in HomeFragment, ProfileFragment and WordDashFragment
- remove now unused imports

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6851f34044108332b31eabb332396bdb