### PR TITLE
Centralize animations

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
+++ b/app/src/main/java/com/gigamind/cognify/CognifyApplication.java
@@ -43,7 +43,7 @@ public class CognifyApplication extends Application {
         boolean darkMode = themePrefs.getBoolean(Constants.PREF_DARK_MODE_ENABLED, false);
         AppCompatDelegate.setDefaultNightMode(darkMode ?
                 AppCompatDelegate.MODE_NIGHT_YES : AppCompatDelegate.MODE_NIGHT_NO);
-        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(this);
+        com.gigamind.cognify.animation.AnimatorProvider.updateFromPreferences(this);
 
         Thread.UncaughtExceptionHandler previousHandler = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler((t, e) -> {

--- a/app/src/main/java/com/gigamind/cognify/animation/AnimationUtils.java
+++ b/app/src/main/java/com/gigamind/cognify/animation/AnimationUtils.java
@@ -1,7 +1,10 @@
-// file: com/gigamind/cognify/util/AnimationUtils.java
-package com.gigamind.cognify.util;
+package com.gigamind.cognify.animation;
 
 import android.view.View;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
+
+import com.gigamind.cognify.R;
 
 public final class AnimationUtils {
     private AnimationUtils() {
@@ -30,5 +33,16 @@ public final class AnimationUtils {
 
     public static void fadeInWithDelay(View view, long delayMs, long duration) {
         AnimatorProvider.get().fadeInWithDelay(view, delayMs, duration);
+    }
+
+    /**
+     * Plays a simple bounce animation on the given view using the bundled
+     * XML animation resource. This keeps XML-based animations alongside the
+     * programmatic ones in this utility class.
+     */
+    public static void bounce(View view) {
+        Animation bounce = AnimationUtils.loadAnimation(
+                view.getContext(), R.anim.button_bounce);
+        view.startAnimation(bounce);
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/animation/AnimatorProvider.java
+++ b/app/src/main/java/com/gigamind/cognify/animation/AnimatorProvider.java
@@ -1,4 +1,6 @@
-package com.gigamind.cognify.util;
+package com.gigamind.cognify.animation;
+
+import com.gigamind.cognify.util.Constants;
 
 /**
  * Simple service locator for {@link ViewAnimator} instances. Allows swapping

--- a/app/src/main/java/com/gigamind/cognify/animation/DefaultViewAnimator.java
+++ b/app/src/main/java/com/gigamind/cognify/animation/DefaultViewAnimator.java
@@ -1,4 +1,4 @@
-package com.gigamind.cognify.util;
+package com.gigamind.cognify.animation;
 
 import android.view.View;
 import android.view.animation.AccelerateDecelerateInterpolator;

--- a/app/src/main/java/com/gigamind/cognify/animation/NoOpViewAnimator.java
+++ b/app/src/main/java/com/gigamind/cognify/animation/NoOpViewAnimator.java
@@ -1,4 +1,4 @@
-package com.gigamind.cognify.util;
+package com.gigamind.cognify.animation;
 
 import android.view.View;
 

--- a/app/src/main/java/com/gigamind/cognify/animation/ViewAnimator.java
+++ b/app/src/main/java/com/gigamind/cognify/animation/ViewAnimator.java
@@ -1,4 +1,4 @@
-package com.gigamind.cognify.util;
+package com.gigamind.cognify.animation;
 
 import android.view.View;
 

--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -262,6 +262,6 @@ public class QuickMathActivity extends AppCompatActivity {
 
     private void triggerFinalCountdown() {
         SoundManager.getInstance(this).playHeartbeat();
-        com.gigamind.cognify.util.AnimationUtils.shake(timerText, 8f);
+        com.gigamind.cognify.animation.AnimationUtils.shake(timerText, 8f);
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -33,7 +33,7 @@ import com.gigamind.cognify.R;
 import com.gigamind.cognify.analytics.GameAnalytics;
 import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.gigamind.cognify.data.repository.UserRepository;
-import com.gigamind.cognify.util.AnimationUtils;
+import com.gigamind.cognify.animation.AnimationUtils;
 import com.gigamind.cognify.util.Constants;
 import com.gigamind.cognify.work.StreakNotificationScheduler;
 import com.google.android.gms.tasks.Task;
@@ -74,7 +74,7 @@ public class ResultActivity extends AppCompatActivity {
         initializeViews();
 
         prefs = getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
-        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(this);
+        com.gigamind.cognify.animation.AnimatorProvider.updateFromPreferences(this);
         userRepository = new UserRepository(this);
         firebaseUser = FirebaseService.getInstance().getCurrentUser();
 
@@ -225,7 +225,7 @@ public class ResultActivity extends AppCompatActivity {
     }
 
     private void animateHeader() {
-        if (!com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled()) {
+        if (!com.gigamind.cognify.animation.AnimatorProvider.isAnimationsEnabled()) {
             headerText.setAlpha(1f);
             return;
         }
@@ -241,7 +241,7 @@ public class ResultActivity extends AppCompatActivity {
             final boolean willSyncRemote,
             final int wordsFound
     ) {
-        if (!com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled()) {
+        if (!com.gigamind.cognify.animation.AnimatorProvider.isAnimationsEnabled()) {
             scoreValue.setText(String.valueOf(finalScore));
             totalWordText.setText(String.valueOf(wordsFound));
             totalXPValue.setText(String.valueOf(finalTotalXp));
@@ -321,7 +321,7 @@ public class ResultActivity extends AppCompatActivity {
     }
 
     private void animateNewHighScoreBanner() {
-        if (!com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled()) {
+        if (!com.gigamind.cognify.animation.AnimatorProvider.isAnimationsEnabled()) {
             newHighScoreText.setVisibility(View.VISIBLE);
             newHighScoreText.setAlpha(1f);
             return;
@@ -343,7 +343,7 @@ public class ResultActivity extends AppCompatActivity {
     }
 
     private void showEncouragement(String message) {
-        if (!com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled()) {
+        if (!com.gigamind.cognify.animation.AnimatorProvider.isAnimationsEnabled()) {
             encouragementText.setText(message.toUpperCase());
             encouragementText.setAlpha(1f);
             return;

--- a/app/src/main/java/com/gigamind/cognify/ui/SplashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/SplashActivity.java
@@ -32,8 +32,8 @@ public class SplashActivity extends AppCompatActivity {
         // Disable heavy animations on low memory devices
         ActivityManager am = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
         SharedPreferences prefs = getSharedPreferences(Constants.PREF_APP, MODE_PRIVATE);
-        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(this);
-        boolean animationsEnabled = com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled();
+        com.gigamind.cognify.animation.AnimatorProvider.updateFromPreferences(this);
+        boolean animationsEnabled = com.gigamind.cognify.animation.AnimatorProvider.isAnimationsEnabled();
         if (!animationsEnabled || (am != null && am.isLowRamDevice())) {
             binding.splashAnimation.cancelAnimation();
             binding.splashAnimation.setVisibility(View.GONE);

--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -235,7 +235,7 @@ public class WordDashActivity extends AppCompatActivity {
     }
 
     private void animateButtonPress(MaterialButton button) {
-        com.gigamind.cognify.util.AnimationUtils.pulse(
+        com.gigamind.cognify.animation.AnimationUtils.pulse(
                 button,
                 1.2f,
                 GameConfig.BUTTON_SCALE_DURATION_MS
@@ -297,7 +297,7 @@ public class WordDashActivity extends AppCompatActivity {
             if (hapticsEnabled) {
                 scoreText.performHapticFeedback(HapticFeedbackConstants.REJECT);
             }
-            com.gigamind.cognify.util.AnimationUtils.shake(letterGrid);
+            com.gigamind.cognify.animation.AnimationUtils.shake(letterGrid);
         }
         clearWord();
         wordStartTime = 0;
@@ -307,7 +307,7 @@ public class WordDashActivity extends AppCompatActivity {
         if (hapticsEnabled) {
             scoreText.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
         }
-        com.gigamind.cognify.util.AnimationUtils.pulse(
+        com.gigamind.cognify.animation.AnimationUtils.pulse(
                 scoreText,
                 1.3f,
                 GameConfig.SCORE_ANIMATION_DURATION_MS
@@ -443,6 +443,6 @@ public class WordDashActivity extends AppCompatActivity {
 
     private void triggerFinalCountdown() {
         SoundManager.getInstance(this).playHeartbeat();
-        com.gigamind.cognify.util.AnimationUtils.shake(timerText, 8f);
+        com.gigamind.cognify.animation.AnimationUtils.shake(timerText, 8f);
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -8,7 +8,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.animation.AnimationUtils;
+import com.gigamind.cognify.animation.AnimationUtils;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import de.hdodenhof.circleimageview.CircleImageView;
@@ -83,7 +83,7 @@ public class HomeFragment extends Fragment {
 
         // Initialize SharedPreferences and UserRepository
         prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
-        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(requireContext());
+        com.gigamind.cognify.animation.AnimatorProvider.updateFromPreferences(requireContext());
         userRepository = new UserRepository(requireContext());
 
         // Check signed-in user
@@ -202,7 +202,7 @@ public class HomeFragment extends Fragment {
     private void setupClickListeners() {
         View.OnClickListener animatedClickListener = v -> {
             if (areAnimationsEnabled()) {
-                v.startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.button_bounce));
+                AnimationUtils.bounce(v);
             }
             handleGameLaunch(v);
         };
@@ -242,7 +242,7 @@ public class HomeFragment extends Fragment {
     }
 
     private boolean areAnimationsEnabled() {
-        return com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled();
+        return com.gigamind.cognify.animation.AnimatorProvider.isAnimationsEnabled();
     }
 
     @Override

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -58,7 +58,7 @@ public class SettingsFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         prefs = requireActivity().getSharedPreferences(Constants.PREF_APP, 0);
-        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(requireContext());
+        com.gigamind.cognify.animation.AnimatorProvider.updateFromPreferences(requireContext());
         GoogleSignInOptions gso = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
                 .requestIdToken(getString(R.string.default_web_client_id))
                 .requestEmail()
@@ -94,7 +94,7 @@ public class SettingsFragment extends Fragment {
 
         binding.animationsSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
                 prefs.edit().putBoolean(KEY_ANIMATIONS_ENABLED, isChecked).apply();
-                com.gigamind.cognify.util.AnimatorProvider.setAnimationsEnabled(isChecked);
+                com.gigamind.cognify.animation.AnimatorProvider.setAnimationsEnabled(isChecked);
                 SoundManager.getInstance(requireContext()).playToggle();
         });
 

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -8,7 +8,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.animation.AnimationUtils;
+import com.gigamind.cognify.animation.AnimationUtils;
 import de.hdodenhof.circleimageview.CircleImageView;
 import android.widget.TextView;
 import com.google.android.material.snackbar.Snackbar;
@@ -72,7 +72,7 @@ public class WordDashFragment extends Fragment {
 
         // Initialize SharedPreferences, repositories and helpers
         prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
-        com.gigamind.cognify.util.AnimatorProvider.updateFromPreferences(requireContext());
+        com.gigamind.cognify.animation.AnimatorProvider.updateFromPreferences(requireContext());
         userRepository = new UserRepository(requireContext());
         tutorialHelper = new TutorialHelper(requireContext());
 
@@ -127,7 +127,7 @@ public class WordDashFragment extends Fragment {
     private void setupClickListeners() {
         View.OnClickListener animatedClickListener = v -> {
             if (areAnimationsEnabled()) {
-                v.startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.button_bounce));
+                AnimationUtils.bounce(v);
             }
             if (!tutorialHelper.isTutorialCompleted()) {
                 String msg = getString(R.string.play_tip);
@@ -171,7 +171,7 @@ public class WordDashFragment extends Fragment {
     }
 
     private boolean areAnimationsEnabled() {
-        return com.gigamind.cognify.util.AnimatorProvider.isAnimationsEnabled();
+        return com.gigamind.cognify.animation.AnimatorProvider.isAnimationsEnabled();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- move all animation helpers to new `animation` package
- expose an XML-driven bounce helper
- update imports and usage across the app

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6851f5bded3c833290eabaa7628c5b69