### PR TITLE
Fix Google sign-in across all Android versions

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -192,28 +192,28 @@ public class OnboardingActivity extends AppCompatActivity {
                 .addCredentialOption(googleIdOption)
                 .build();
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            credentialManager.getCredentialAsync(
-                    this,
-                    request,
-                            new CancellationSignal(),
-                            getMainExecutor(),
-                            new CredentialManagerCallback<GetCredentialResponse, GetCredentialException>() {
-                                @Override
-                                public void onResult(GetCredentialResponse result) {
-                                    handleSignIn(result);
-                                }
+        // CredentialManager supports back to API 21 via Play Services, so no
+        // SDK version check is necessary here.
+        credentialManager.getCredentialAsync(
+                this,
+                request,
+                new CancellationSignal(),
+                getMainExecutor(),
+                new CredentialManagerCallback<GetCredentialResponse, GetCredentialException>() {
+                    @Override
+                    public void onResult(GetCredentialResponse result) {
+                        handleSignIn(result);
+                    }
 
-                                @Override
-                                public void onError(GetCredentialException e) {
-                                    ExceptionLogger.log("OnboardingActivity", e);
-                                    String msg = getString(R.string.google_sign_in_failed);
-                                    Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
-                                    binding.getRoot().announceForAccessibility(msg);
-                                }
-                            }
-                    );
-        }
+                    @Override
+                    public void onError(GetCredentialException e) {
+                        ExceptionLogger.log("OnboardingActivity", e);
+                        String msg = getString(R.string.google_sign_in_failed);
+                        Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_LONG).show();
+                        binding.getRoot().announceForAccessibility(msg);
+                    }
+                }
+        );
     }
 
     private void handleSignIn(GetCredentialResponse result) {


### PR DESCRIPTION
## Summary
- remove Android version check so CredentialManager runs on all supported devices

## Testing
- `./gradlew test --stacktrace` *(fails: unable to download Gradle wrapper due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68524f177dc88332b0ffd246ae5589bb