### PR TITLE
Fix Google sign‑in imports

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,10 +74,6 @@ dependencies {
     implementation(libs.glide)
     implementation(libs.flexbox)
 
-    implementation(libs.credentials)
-    implementation(libs.credentials.play.services.auth)
-    implementation (libs.googleid)
-
     testImplementation(libs.junit)
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")

--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -2,14 +2,12 @@ package com.gigamind.cognify.ui;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption;
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential;
-import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException;
 import com.google.android.material.snackbar.Snackbar;
 
 import androidx.appcompat.app.AppCompatActivity;

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -22,7 +22,6 @@ import com.gigamind.cognify.ui.OnboardingActivity;
 import com.gigamind.cognify.util.Constants;
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption;
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential;
-import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.gigamind.cognify.util.SoundManager;


### PR DESCRIPTION
## Summary
- remove duplicate dependencies in `build.gradle.kts`
- remove unused imports from Google sign-in classes

## Testing
- `./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68524fe7632c8332abb1759b8a528766