### PR TITLE
Fix Google sign-in builder options

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -9,6 +9,7 @@ import android.view.ViewGroup;
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption;
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential;
 import com.google.android.material.snackbar.Snackbar;
+import java.util.UUID;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -184,6 +185,8 @@ public class OnboardingActivity extends AppCompatActivity {
         GetGoogleIdOption googleIdOption = new GetGoogleIdOption.Builder()
                 .setFilterByAuthorizedAccounts(false)
                 .setServerClientId(getString(R.string.default_web_client_id))
+                .setAutoSelectEnabled(true)
+                .setNonce(UUID.randomUUID().toString())
                 .build();
 
         GetCredentialRequest request = new GetCredentialRequest.Builder()

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -40,6 +40,7 @@ import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.GoogleAuthProvider;
 import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
 import com.gigamind.cognify.util.ExceptionLogger;
+import java.util.UUID;
 
 public class SettingsFragment extends Fragment {
     private FragmentSettingsBinding binding;
@@ -193,6 +194,8 @@ public class SettingsFragment extends Fragment {
         GetGoogleIdOption option = new GetGoogleIdOption.Builder()
                 .setFilterByAuthorizedAccounts(true)
                 .setServerClientId(getString(R.string.default_web_client_id))
+                .setAutoSelectEnabled(true)
+                .setNonce(UUID.randomUUID().toString())
                 .build();
 
         GetCredentialRequest request = new GetCredentialRequest.Builder()


### PR DESCRIPTION
## Summary
- enable auto-select and nonce when starting Google sign-in flows
- apply same settings to reauthentication flow

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685251d9226883329701cfe17f772361