### PR TITLE
Integrate reusable Google sign‑in helper

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/util/GoogleSignInHelper.java
+++ b/app/src/main/java/com/gigamind/cognify/util/GoogleSignInHelper.java
@@ -1,0 +1,76 @@
+package com.gigamind.cognify.util;
+
+import android.app.Activity;
+import android.os.CancellationSignal;
+
+import androidx.credentials.CredentialManager;
+import androidx.credentials.CredentialManagerCallback;
+import androidx.credentials.GetCredentialRequest;
+import androidx.credentials.GetCredentialResponse;
+import androidx.credentials.exceptions.GetCredentialException;
+import androidx.credentials.CustomCredential;
+import androidx.credentials.PasswordCredential;
+import androidx.credentials.PublicKeyCredential;
+
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption;
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential;
+
+import java.util.UUID;
+
+import com.gigamind.cognify.R;
+
+public class GoogleSignInHelper {
+
+    public interface Callback {
+        void onSuccess(String idToken);
+        void onError(Exception e);
+    }
+
+    public static void signIn(Activity activity, Callback callback) {
+        CredentialManager credentialManager = CredentialManager.create(activity);
+
+        GetGoogleIdOption googleIdOption = new GetGoogleIdOption.Builder()
+                .setFilterByAuthorizedAccounts(false)
+                .setServerClientId(activity.getString(R.string.default_web_client_id))
+                .setAutoSelectEnabled(true)
+                .setNonce(UUID.randomUUID().toString())
+                .build();
+
+        GetCredentialRequest request = new GetCredentialRequest.Builder()
+                .addCredentialOption(googleIdOption)
+                .build();
+
+        credentialManager.getCredentialAsync(
+                activity,
+                request,
+                new CancellationSignal(),
+                activity.getMainExecutor(),
+                new CredentialManagerCallback<GetCredentialResponse, GetCredentialException>() {
+                    @Override
+                    public void onResult(GetCredentialResponse result) {
+                        handleResult(result, callback);
+                    }
+
+                    @Override
+                    public void onError(GetCredentialException e) {
+                        callback.onError(e);
+                    }
+                }
+        );
+    }
+
+    private static void handleResult(GetCredentialResponse result, Callback callback) {
+        androidx.credentials.Credential credential = result.getCredential();
+        if (credential instanceof CustomCredential) {
+            CustomCredential cc = (CustomCredential) credential;
+            if (GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL.equals(cc.getType())) {
+                GoogleIdTokenCredential googleIdTokenCredential = GoogleIdTokenCredential.createFrom(cc.getData());
+                callback.onSuccess(googleIdTokenCredential.getIdToken());
+            } else {
+                callback.onError(new Exception("Unexpected credential type"));
+            }
+        } else if (credential instanceof PasswordCredential || credential instanceof PublicKeyCredential) {
+            callback.onError(new Exception("Unexpected credential"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `GoogleSignInHelper` for Credential Manager Google ID sign-in
- refactor `OnboardingActivity` to use the helper for sign-in

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68525ef32be48332a35fedbba8c89f4d