### PR TITLE
Add confirmation toast after account deletion

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -23,6 +23,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.gigamind.cognify.util.SoundManager;
 import com.gigamind.cognify.util.GoogleSignInHelper;
+import android.widget.Toast;
 
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.auth.AuthCredential;
@@ -202,6 +203,7 @@ public class SettingsFragment extends Fragment {
                 .addOnSuccessListener(aVoid -> FirebaseService.getInstance().deleteAccountAndData()
                         .addOnSuccessListener(v -> {
                             String msg = getString(R.string.account_deleted);
+                            Toast.makeText(requireContext(), msg, Toast.LENGTH_LONG).show();
                             Snackbar.make(binding.getRoot(), msg, Snackbar.LENGTH_SHORT).show();
                             binding.getRoot().announceForAccessibility(msg);
                             startActivity(new Intent(requireActivity(), OnboardingActivity.class)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,7 +232,7 @@
     <string name="hair_bun">Hair Bun</string>
     <string name="hair_curly">Curly Hair</string>
     <string name="delete_account_error">Failed to delete account: %1$s</string>
-    <string name="account_deleted">Account deleted successfully</string>
+    <string name="account_deleted">Your account and all data have been deleted from our database</string>
     <string name="play_services_required">Google Play Services required for sign in.</string>
     <string name="google_sign_in_failed">Google sign in failed.</string>
 </resources>


### PR DESCRIPTION
## Summary
- show a Toast message when the user account and data are removed
- update account deletion message

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68528fe4bf008332843bce960925efa9