### PR TITLE
Fix Google sign-in failure after account deletion

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/util/GoogleSignInHelper.java
+++ b/app/src/main/java/com/gigamind/cognify/util/GoogleSignInHelper.java
@@ -32,7 +32,7 @@ public class GoogleSignInHelper {
         GetGoogleIdOption googleIdOption = new GetGoogleIdOption.Builder()
                 .setFilterByAuthorizedAccounts(filterByAuthorizedAccounts)
                 .setServerClientId(activity.getString(R.string.default_web_client_id))
-                .setAutoSelectEnabled(true)
+                .setAutoSelectEnabled(false)
                 .setNonce(UUID.randomUUID().toString())
                 .build();
 


### PR DESCRIPTION
## Summary
- disable auto-select in `GoogleSignInHelper`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68529086ebec8332a17d0c6b88a64888