### PR TITLE
Improve onboarding transition

### DIFF
--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -79,4 +79,15 @@
             android:layout_marginBottom="16dp" />
     </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout> 
+    <ProgressBar
+        android:id="@+id/loadingIndicator"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- add loading indicator for onboarding
- add fade transition when launching `MainActivity`
- show progress while signing in or continuing as guest

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download Gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685291d6f62c8332ac25d68bb53b230d