### PR TITLE
Enhance scoring for larger challenges

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/engine/MathGameEngine.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/MathGameEngine.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Random;
 
 import com.gigamind.cognify.util.GameConfig;
-import com.gigamind.cognify.engine.scoring.DefaultMathScoreStrategy;
+import com.gigamind.cognify.engine.scoring.ExponentialMathScoreStrategy;
 import com.gigamind.cognify.engine.scoring.MathScoreStrategy;
 
 public class MathGameEngine {
@@ -18,13 +18,13 @@ public class MathGameEngine {
     private int currentDifficulty;
 
     public MathGameEngine() {
-        this(new DefaultMathScoreStrategy());
+        this(new ExponentialMathScoreStrategy());
     }
 
     public MathGameEngine(MathScoreStrategy strategy) {
         random = new Random();
         currentOptions = new ArrayList<>();
-        scoreStrategy = strategy != null ? strategy : new DefaultMathScoreStrategy();
+        scoreStrategy = strategy != null ? strategy : new ExponentialMathScoreStrategy();
     }
 
     public void generateQuestion() {

--- a/app/src/main/java/com/gigamind/cognify/engine/WordGameEngine.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/WordGameEngine.java
@@ -14,7 +14,7 @@ import java.io.InputStreamReader;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.gigamind.cognify.engine.scoring.DefaultWordScoreStrategy;
+import com.gigamind.cognify.engine.scoring.ExponentialWordScoreStrategy;
 import com.gigamind.cognify.engine.scoring.ScoreStrategy;
 import com.gigamind.cognify.engine.GridGenerator;
 import com.gigamind.cognify.engine.RandomGridGenerator;
@@ -28,7 +28,7 @@ public class WordGameEngine {
     private char[] currentGrid;
 
     public WordGameEngine(Set<String> dictionary) {
-        this(dictionary, new DefaultWordScoreStrategy(), new RandomGridGenerator());
+        this(dictionary, new ExponentialWordScoreStrategy(), new RandomGridGenerator());
     }
 
     public WordGameEngine(Set<String> dictionary, ScoreStrategy strategy) {
@@ -37,7 +37,7 @@ public class WordGameEngine {
 
     public WordGameEngine(Set<String> dictionary, ScoreStrategy strategy, GridGenerator generator) {
         this.dictionary = dictionary;
-        this.scoreStrategy = strategy != null ? strategy : new DefaultWordScoreStrategy();
+        this.scoreStrategy = strategy != null ? strategy : new ExponentialWordScoreStrategy();
         this.gridGenerator = generator != null ? generator : new RandomGridGenerator();
         this.currentGrid = generateGrid();
     }
@@ -48,7 +48,7 @@ public class WordGameEngine {
      * built‑in "words.txt" file.
      */
     public WordGameEngine(Context context) {
-        this(context, new DefaultWordScoreStrategy());
+        this(context, new ExponentialWordScoreStrategy());
     }
 
     public WordGameEngine(Context context, ScoreStrategy strategy) {

--- a/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialMathScoreStrategy.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialMathScoreStrategy.java
@@ -1,0 +1,24 @@
+package com.gigamind.cognify.engine.scoring;
+
+import com.gigamind.cognify.util.GameConfig;
+
+/**
+ * Math scoring strategy that heavily rewards higher difficulty
+ * questions. Score grows with the square of the difficulty level
+ * so that solving complex problems yields substantially more points.
+ */
+public class ExponentialMathScoreStrategy implements MathScoreStrategy {
+    @Override
+    public int calculateScore(boolean correct, long responseTimeMs, int difficulty) {
+        if (!correct) {
+            return -5;
+        }
+
+        int diffFactor = difficulty * difficulty;
+        int base = GameConfig.BASE_SCORE * diffFactor;
+        long clamped = Math.min(responseTimeMs, GameConfig.MAX_RESPONSE_TIME_MS);
+        double timeFactor = 1.0 + (double) (GameConfig.MAX_RESPONSE_TIME_MS - clamped)
+                / GameConfig.MAX_RESPONSE_TIME_MS;
+        return (int) Math.round(base * timeFactor);
+    }
+}

--- a/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialWordScoreStrategy.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialWordScoreStrategy.java
@@ -1,0 +1,29 @@
+package com.gigamind.cognify.engine.scoring;
+
+import com.gigamind.cognify.util.GameConfig;
+
+/**
+ * Scoring strategy that rewards longer words exponentially.
+ * Words that exceed the minimum length earn disproportionately
+ * higher scores, encouraging players to tackle larger words.
+ */
+public class ExponentialWordScoreStrategy implements ScoreStrategy {
+    @Override
+    public int calculateScore(String word) {
+        if (word == null || word.length() < GameConfig.MIN_WORD_LENGTH) {
+            return 0;
+        }
+
+        int lengthFactor = word.length() - GameConfig.MIN_WORD_LENGTH + 1;
+        int score = GameConfig.BASE_SCORE * lengthFactor * lengthFactor;
+
+        for (char c : word.toCharArray()) {
+            if ("JQXZ".indexOf(c) >= 0) {
+                score += GameConfig.COMPLEXITY_BONUS * lengthFactor;
+            } else if ("KWVY".indexOf(c) >= 0) {
+                score += (GameConfig.COMPLEXITY_BONUS / 2) * lengthFactor;
+            }
+        }
+        return score;
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
@@ -57,7 +57,8 @@ public class MathGameEngineTest {
         assertTrue(engine.checkAnswer(correct));
         assertFalse(engine.checkAnswer(correct + 1));
 
-        int base = GameConfig.BASE_SCORE * engine.getCurrentDifficulty();
+        int difficulty = engine.getCurrentDifficulty();
+        int base = GameConfig.BASE_SCORE * difficulty * difficulty;
         // At 0 ms response time, points are doubled
         assertEquals(base * 2, engine.getScore(true, 0));
         assertEquals(-5, engine.getScore(false, 0));

--- a/app/src/test/java/com/gigamind/cognify/engine/WordGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/WordGameEngineTest.java
@@ -62,13 +62,12 @@ public class WordGameEngineTest {
         // Base score 10 plus length bonus (3 letters -> 0) = 10
         assertEquals(10, engine.calculateScore("CAT"));
 
-        // Word with uncommon letters Q and Z should give complexity bonus
-        assertEquals(31, engine.calculateScore("QUIZ"));
+        // Word with uncommon letters Q and Z should give larger bonus
+        assertEquals(72, engine.calculateScore("QUIZ"));
 
         // Word with half complexity letters like W should add half bonus
         dictionary.add("BOW");
-        assertEquals(10 + GameConfig.LENGTH_BONUS + GameConfig.COMPLEXITY_BONUS / 2,
-                engine.calculateScore("BOW"));
+        assertEquals(14, engine.calculateScore("BOW"));
 
         // Invalid word should yield zero
         assertEquals(0, engine.calculateScore("BIRD"));

--- a/app/src/test/java/com/gigamind/cognify/engine/scoring/ExponentialMathScoreStrategyTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/scoring/ExponentialMathScoreStrategyTest.java
@@ -1,0 +1,22 @@
+package com.gigamind.cognify.engine.scoring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExponentialMathScoreStrategyTest {
+
+    @Test
+    void testHigherDifficultyScoresMore() {
+        MathScoreStrategy strategy = new ExponentialMathScoreStrategy();
+        int easy = strategy.calculateScore(true, 0, 1);
+        int hard = strategy.calculateScore(true, 0, 3);
+        assertTrue(hard > easy);
+    }
+
+    @Test
+    void testIncorrectAnswerPenalized() {
+        MathScoreStrategy strategy = new ExponentialMathScoreStrategy();
+        assertEquals(-5, strategy.calculateScore(false, 1000, 2));
+    }
+}

--- a/app/src/test/java/com/gigamind/cognify/engine/scoring/ExponentialWordScoreStrategyTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/scoring/ExponentialWordScoreStrategyTest.java
@@ -1,0 +1,21 @@
+package com.gigamind.cognify.engine.scoring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExponentialWordScoreStrategyTest {
+
+    @Test
+    void testLongWordScoresHigher() {
+        ScoreStrategy strategy = new ExponentialWordScoreStrategy();
+        assertTrue(strategy.calculateScore("QUIZ") > strategy.calculateScore("CAT"));
+    }
+
+    @Test
+    void testInvalidWordReturnsZero() {
+        ScoreStrategy strategy = new ExponentialWordScoreStrategy();
+        assertEquals(0, strategy.calculateScore(null));
+        assertEquals(0, strategy.calculateScore("hi"));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ExponentialWordScoreStrategy` and `ExponentialMathScoreStrategy`
- make `WordGameEngine` and `MathGameEngine` use the new strategies by default
- update engine tests for new scoring math
- add new unit tests covering the exponential strategies

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6852a37aa7048332ad92aa07e695b2ec