### PR TITLE
Redesign home quest card and fix daily challenge launch

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -56,6 +56,8 @@ public class HomeFragment extends Fragment {
     private TextView questDescription;
     private TextView questReward;
     private CircleImageView currentUserAvatar;
+    /** Flag cached from setupDailyChallenge to know which game is today's challenge */
+    private boolean isWordDay;
     private SharedPreferences prefs;
     private UserRepository userRepository;
     private FirebaseUser firebaseUser;
@@ -159,8 +161,11 @@ public class HomeFragment extends Fragment {
      */
     private void setupDailyChallenge() {
         Calendar calendar = Calendar.getInstance();
-        boolean isWordDay = (calendar.get(Calendar.DAY_OF_WEEK) % 2) == 0;
-        String challengeType = isWordDay ? getString(R.string.word_dash) : getString(R.string.quick_math);
+        // Cache today's challenge so click handling knows which game to launch
+        isWordDay = (calendar.get(Calendar.DAY_OF_WEEK) % 2) == 0;
+        String challengeType = isWordDay
+                ? getString(R.string.word_dash)
+                : getString(R.string.quick_math);
         dailyChallengeTitle.setText(challengeType);
 
         // Use a consistent "YYYY-DDD" key in prefs to mark completion
@@ -220,9 +225,21 @@ public class HomeFragment extends Fragment {
      * and whether it was the daily challenge. Also marks daily challenge complete.
      */
     private void handleGameLaunch(View v) {
-        boolean isDaily = (v.getId() == R.id.welcomeCardView);
+        boolean isDaily = (v.getId() == R.id.welcomeCardView
+                || v.getId() == R.id.dailyChallengeTitle);
+
+        boolean openWordDash;
+        if (v.getId() == R.id.wordGameCard || v == binding.wordGameCard.playButton) {
+            openWordDash = true;
+        } else if (v.getId() == R.id.mathGameCard || v == binding.mathGameCard.playButton) {
+            openWordDash = false;
+        } else {
+            // Daily challenge card or title - follow today's designated game
+            openWordDash = isWordDay;
+        }
+
         Intent intent;
-        if (v.getId() == R.id.wordGameCard || v == binding.wordGameCard.playButton || v.getId() == R.id.welcomeCardView) {
+        if (openWordDash) {
             intent = new Intent(getContext(), WordDashActivity.class);
             intent.putExtra(Constants.INTENT_GAME_TYPE, Constants.GAME_TYPE_WORD);
         } else {

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -170,33 +170,48 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
                 android:padding="16dp">
 
-                <TextView
-                    android:id="@+id/questTitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/daily_quest"
-                    android:textColor="@android:color/white"
-                    android:textSize="16sp"
-                    android:textStyle="bold" />
+                <ImageView
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:layout_marginEnd="12dp"
+                    android:contentDescription="@string/daily_quest"
+                    android:src="@drawable/rewards" />
 
-                <TextView
-                    android:id="@+id/questDescription"
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:textColor="@android:color/white"
-                    android:textSize="14sp" />
+                    android:layout_weight="1"
+                    android:orientation="vertical">
 
-                <TextView
-                    android:id="@+id/questReward"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:textColor="#FFFF00"
-                    android:textSize="14sp" />
+                    <TextView
+                        android:id="@+id/questTitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/daily_quest"
+                        android:textColor="@android:color/white"
+                        android:textSize="16sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/questDescription"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textColor="@android:color/white"
+                        android:textSize="14sp" />
+
+                    <TextView
+                        android:id="@+id/questReward"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textColor="#FFFF00"
+                        android:textSize="14sp" />
+                </LinearLayout>
             </LinearLayout>
         </androidx.cardview.widget.CardView>
 


### PR DESCRIPTION
## Summary
- tweak HomeFragment to track daily challenge type
- launch correct game from the home screen
- redesign quest card with icon and horizontal layout for clarity

## Testing
- `./gradlew test` *(fails: HTTP 403 when downloading Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6852a89b897083328d97dc7cace25f92