### PR TITLE
Reduce jump between word scores

### DIFF
--- a/SCORING.md
+++ b/SCORING.md
@@ -11,13 +11,11 @@ Word Dash challenges you to form words from a random 4×4 grid. Words are valid 
 - **Complexity bonus:** uncommon letters earn more:
   - `+8` for each J, Q, X or Z
   - `+4` for each K, W, V or Y
-- **Exponential strategy:** by default the game uses an exponential strategy where
-  the base score grows with the square of the word length. Complexity bonuses are
-  multiplied by this length factor as well.
+- **Balanced exponential strategy:** scores still grow with the square of the word length but are scaled down to avoid huge jumps. Complexity bonuses are multiplied by this length factor.
 
 ```
 lengthFactor = wordLength - MIN_WORD_LENGTH + 1
-score = BASE_SCORE * lengthFactor^2 + complexityBonus * lengthFactor
+score = (BASE_SCORE / 2) * lengthFactor^2 + (BASE_SCORE / 2) + complexityBonus * lengthFactor
 ```
 
 ## Quick Math

--- a/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialWordScoreStrategy.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialWordScoreStrategy.java
@@ -3,9 +3,10 @@ package com.gigamind.cognify.engine.scoring;
 import com.gigamind.cognify.util.GameConfig;
 
 /**
- * Scoring strategy that rewards longer words exponentially.
- * Words that exceed the minimum length earn disproportionately
- * higher scores, encouraging players to tackle larger words.
+ * Scoring strategy that rewards longer words using a tempered
+ * quadratic function. The growth is still based on the square of
+ * the length factor but scaled down so scores remain reasonable
+ * while still incentivising bigger words.
  */
 public class ExponentialWordScoreStrategy implements ScoreStrategy {
     @Override
@@ -15,7 +16,10 @@ public class ExponentialWordScoreStrategy implements ScoreStrategy {
         }
 
         int lengthFactor = word.length() - GameConfig.MIN_WORD_LENGTH + 1;
-        int score = GameConfig.BASE_SCORE * lengthFactor * lengthFactor;
+        // Scale the quadratic growth so larger words are rewarded
+        // without skyrocketing the score.
+        int score = (GameConfig.BASE_SCORE / 2) * lengthFactor * lengthFactor
+                + (GameConfig.BASE_SCORE / 2);
 
         for (char c : word.toCharArray()) {
             if ("JQXZ".indexOf(c) >= 0) {

--- a/app/src/test/java/com/gigamind/cognify/engine/WordGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/WordGameEngineTest.java
@@ -59,11 +59,11 @@ public class WordGameEngineTest {
 
     @Test
     void testCalculateScore() {
-        // Base score 10 plus length bonus (3 letters -> 0) = 10
+        // Base score 10 for a minimum length word
         assertEquals(10, engine.calculateScore("CAT"));
 
         // Word with uncommon letters Q and Z should give larger bonus
-        assertEquals(72, engine.calculateScore("QUIZ"));
+        assertEquals(57, engine.calculateScore("QUIZ"));
 
         // Word with half complexity letters like W should add half bonus
         dictionary.add("BOW");


### PR DESCRIPTION
## Summary
- scale down Word Dash scoring to avoid huge jumps between word lengths
- document the balanced scoring formula
- update unit test expectations

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6852addc93cc8332b5d95d1c6591b377