### PR TITLE
Add popups showing points earned

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -171,6 +171,7 @@ public class QuickMathActivity extends BaseActivity {
         currentScore += points;
         questionCount++;
         scoreText.setText(String.valueOf(currentScore));
+        showPointsPopup(points);
 
         // Visual feedback (could be enhanced with animations)
         answerButtons[buttonIndex].setBackgroundTintList(
@@ -258,6 +259,13 @@ public class QuickMathActivity extends BaseActivity {
         for (MaterialButton btn : answerButtons) {
             btn.setEnabled(enabled);
         }
+    }
+
+    private void showPointsPopup(int points) {
+        View root = findViewById(android.R.id.content);
+        String msg = getString(R.string.points_popup_format, points);
+        Snackbar.make(root, msg, Snackbar.LENGTH_SHORT).show();
+        root.announceForAccessibility(msg);
     }
 
     private void triggerFinalCountdown() {

--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -280,6 +280,7 @@ public class WordDashActivity extends BaseActivity {
             analytics.logWordFound(word, timeSpent);
             SoundManager.getInstance(this).playCorrect();
             animateScoreIncrease();
+            showPointsPopup(points);
 
             foundWordsList.add(word);
             foundWordsAdapter.submitList(new ArrayList<>(foundWordsList));
@@ -328,6 +329,13 @@ public class WordDashActivity extends BaseActivity {
     private void clearWord() {
         currentWord.setLength(0);
         currentWordText.setText("");
+    }
+
+    private void showPointsPopup(int points) {
+        View root = findViewById(android.R.id.content);
+        String msg = getString(R.string.points_popup_format, points);
+        Snackbar.make(root, msg, Snackbar.LENGTH_SHORT).show();
+        root.announceForAccessibility(msg);
     }
 
     private void startGame() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,5 +236,6 @@
 
     <string name="welcome_card_title">Welcome to Cognify!</string>
     <string name="welcome_card_subtitle">Lets start to Learn and Play the game</string>
+    <string name="points_popup_format">%+d points</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- show a small popup with points earned after each answer in **QuickMathActivity** and **WordDashActivity**
- add helper method `showPointsPopup`
- add a `points_popup_format` string resource

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6852b40423e88332b311a9854af6eed1