### PR TITLE
Fix game card layout in home fragment

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -174,10 +174,12 @@ public class HomeFragment extends Fragment {
         // Word Dash card
         binding.wordGameCard.cardTitle.setText(getString(R.string.word_dash));
         binding.wordGameCard.container.setBackgroundResource(R.drawable.bg_card_word);
+        binding.wordGameCard.logoImage.setImageResource(R.drawable.ic_word_logo);
 
         // Quick Math card overrides default accent color
         binding.mathGameCard.cardTitle.setText(getString(R.string.quick_math));
         binding.mathGameCard.container.setBackgroundResource(R.drawable.bg_card_math);
+        binding.mathGameCard.logoImage.setImageResource(R.drawable.ic_math_logo);
         int mathColor = Color.parseColor("#B8860B");
         binding.mathGameCard.playButton.setBackgroundTintList(ColorStateList.valueOf(mathColor));
         binding.mathGameCard.playButton.setRippleColor(ColorStateList.valueOf(mathColor));

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -173,7 +173,7 @@
             <include
                 android:id="@+id/wordGameCard"
                 layout="@layout/game_card"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_margin="8dp"
                 android:layout_weight="1" />
@@ -181,7 +181,7 @@
             <include
                 android:id="@+id/mathGameCard"
                 layout="@layout/game_card"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_margin="8dp"
                 android:layout_weight="1" />

--- a/app/src/main/res/layout/game_card.xml
+++ b/app/src/main/res/layout/game_card.xml
@@ -2,7 +2,7 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:layout_margin="8dp"
     app:cardCornerRadius="24dp"
     app:cardElevation="4dp"
@@ -12,7 +12,7 @@
     <LinearLayout
         android:id="@+id/container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
         android:padding="16dp">
 
@@ -29,10 +29,14 @@
             android:textStyle="bold" />
 
         <ImageView
+            android:id="@+id/logoImage"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="0dp"
             android:layout_gravity="center"
-            android:src="@drawable/ic_math_logo"/>
+            android:layout_weight="1"
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_math_logo" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/playButton"


### PR DESCRIPTION
## Summary
- fix layout properties for `game_card`
- prevent stretching of game cards in `fragment_home`
- apply correct icons for Word Dash and Quick Math

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853200021b88332972e0ab15a8731c1