### PR TITLE
Implement daily challenge info on home card

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -45,6 +45,7 @@ public class HomeFragment extends Fragment {
     MaterialButton quickMathPlayButton;
     private FragmentHomeBinding binding;
     private TextView dailyChallengeTitle;
+    private TextView dailyChallengeGame;
     private CardView playWordDashButton;
     private CardView playQuickMathButton;
     private RelativeLayout cardView;
@@ -107,6 +108,7 @@ public class HomeFragment extends Fragment {
      */
     private void initializeViews() {
         dailyChallengeTitle = binding.dailyChallengeTitle;
+        dailyChallengeGame = binding.dailyChallengeGame;
         playWordDashButton = binding.wordGameCard.getRoot();
         playQuickMathButton = binding.mathGameCard.getRoot();
         cardView = binding.welcomeCardView;
@@ -159,7 +161,8 @@ public class HomeFragment extends Fragment {
         String challengeType = isWordDay
                 ? getString(R.string.word_dash)
                 : getString(R.string.quick_math);
-        dailyChallengeTitle.setText(challengeType);
+        dailyChallengeTitle.setText(R.string.daily_challenge);
+        dailyChallengeGame.setText(getString(R.string.today_challenge_format, challengeType));
         dailyChallengeLogo.setImageResource(
                 isWordDay ? R.drawable.ic_word_logo : R.drawable.ic_math_logo);
 
@@ -203,6 +206,7 @@ public class HomeFragment extends Fragment {
         };
 
         dailyChallengeTitle.setOnClickListener(animatedClickListener);
+        dailyChallengeGame.setOnClickListener(animatedClickListener);
         playWordDashButton.setOnClickListener(animatedClickListener);
         playQuickMathButton.setOnClickListener(animatedClickListener);
         wordGamePlayButton.setOnClickListener(animatedClickListener);
@@ -216,7 +220,8 @@ public class HomeFragment extends Fragment {
      */
     private void handleGameLaunch(View v) {
         boolean isDaily = (v.getId() == R.id.welcomeCardView
-                || v.getId() == R.id.dailyChallengeTitle);
+                || v.getId() == R.id.dailyChallengeTitle
+                || v.getId() == R.id.dailyChallengeGame);
         if (isDaily && DailyChallengeManager.isCompleted(requireContext())) {
             Snackbar.make(binding.getRoot(),
                     getString(R.string.daily_completed_msg),

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -119,6 +119,13 @@
                             android:textStyle="bold" />
 
                         <TextView
+                            android:id="@+id/dailyChallengeGame"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@android:color/white"
+                            android:textSize="14sp" />
+
+                        <TextView
                             android:id="@+id/dailyPerk"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,7 @@
     <string name="badge_legend">Legend</string>
     <string name="perk_format">Perk: %1$s</string>
     <string name="daily_completed_msg">Daily challenge already completed today.</string>
+    <string name="today_challenge_format">Today: %1$s</string>
     <string name="play_tip">You\u2019ll see a quick tutorial first.</string>
     <string name="tutorial_start_hint">Tap letters to form a word, then hit Submit.</string>
     <string name="tutorial_complete">Great! Tutorial complete.</string>


### PR DESCRIPTION
## Summary
- show today's daily challenge game on the home card
- wire click handling for the new label

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853286610d8833282dc20f378a7de4e