### PR TITLE
Add avatar navigation to profile

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -30,6 +30,7 @@ import com.gigamind.cognify.util.DailyChallengeManager;
 import android.graphics.Color;
 import android.content.res.ColorStateList;
 import com.google.android.material.button.MaterialButton;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.snackbar.Snackbar;
 import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.google.firebase.auth.FirebaseUser;
@@ -211,6 +212,11 @@ public class HomeFragment extends Fragment {
         wordGamePlayButton.setOnClickListener(animatedClickListener);
         quickMathPlayButton.setOnClickListener(animatedClickListener);
         cardView.setOnClickListener(animatedClickListener);
+
+        currentUserAvatar.setOnClickListener(v -> {
+            BottomNavigationView bottomNav = requireActivity().findViewById(R.id.bottomNavigation);
+            bottomNav.setSelectedItemId(R.id.navigation_profile);
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
- navigate to profile tab when tapping profile picture on Home screen

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68533084b80c8332bad6b300655d0bef