### PR TITLE
Balance Quick Math scoring

### DIFF
--- a/SCORING.md
+++ b/SCORING.md
@@ -22,25 +22,22 @@ score = BASE_SCORE * lengthFactor^2 + complexityBonus * lengthFactor
 
 ## Quick Math
 
-Quick Math presents rapid arithmetic questions with weighted difficulty. Each
-answer yields points as follows:
+Quick Math presents rapid arithmetic questions with weighted difficulty. The
+formula mirrors the exponential rules from **Word Dash** so that both games
+grant comparable points. Each answer yields points as follows:
 
 ```
 if wrong:
     score = -5
 else:
-    base = BASE_SCORE * difficulty^2
-    timeFactor = 1 + (MAX_RESPONSE_TIME_MS - responseTime) / MAX_RESPONSE_TIME_MS
-    score = round(base * timeFactor)
+    diffFactor = difficulty
+    base = BASE_SCORE * diffFactor^2
+    bonus = LENGTH_BONUS * diffFactor
+            * (MAX_RESPONSE_TIME_MS - responseTime) / MAX_RESPONSE_TIME_MS
+    score = round(base + bonus)
 ```
 
-At the end of the round, scores are normalised:
-
-```
-normalizedScore = (totalScore / questionsAnswered) * SCORE_NORMALIZATION_SCALE
-```
-
-where `SCORE_NORMALIZATION_SCALE` is `10`.
+The final game score is the sum of all question scores (no normalisation).
 
 ## Experience & Bonuses
 

--- a/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialMathScoreStrategy.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialMathScoreStrategy.java
@@ -3,9 +3,11 @@ package com.gigamind.cognify.engine.scoring;
 import com.gigamind.cognify.util.GameConfig;
 
 /**
- * Math scoring strategy that heavily rewards higher difficulty
- * questions. Score grows with the square of the difficulty level
- * so that solving complex problems yields substantially more points.
+ * Math scoring strategy inspired by {@link ExponentialWordScoreStrategy}.
+ * Base points grow with the square of the difficulty level just like
+ * longer words earn more in Word Dash. A small bonus is added for fast
+ * responses instead of multiplying the entire score, keeping totals
+ * closer to the word game.
  */
 public class ExponentialMathScoreStrategy implements MathScoreStrategy {
     @Override
@@ -14,11 +16,14 @@ public class ExponentialMathScoreStrategy implements MathScoreStrategy {
             return -5;
         }
 
-        int diffFactor = difficulty * difficulty;
-        int base = GameConfig.BASE_SCORE * diffFactor;
+        int diffFactor = difficulty;
+        int base = GameConfig.BASE_SCORE * diffFactor * diffFactor;
         long clamped = Math.min(responseTimeMs, GameConfig.MAX_RESPONSE_TIME_MS);
-        double timeFactor = 1.0 + (double) (GameConfig.MAX_RESPONSE_TIME_MS - clamped)
+
+        double bonusFactor = (double) (GameConfig.MAX_RESPONSE_TIME_MS - clamped)
                 / GameConfig.MAX_RESPONSE_TIME_MS;
-        return (int) Math.round(base * timeFactor);
+        double bonus = GameConfig.LENGTH_BONUS * diffFactor * bonusFactor;
+
+        return (int) Math.round(base + bonus);
     }
 }

--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -192,17 +192,14 @@ public class QuickMathActivity extends AppCompatActivity {
             gameTimer = null;
         }
         timeRemaining = 0;
-        int normalized = questionCount > 0
-                ? Math.round((float) currentScore / questionCount
-                        * GameConfig.SCORE_NORMALIZATION_SCALE)
-                : 0;
+        int finalScore = currentScore;
         analytics.logGameEnd(GameType.MATH,
-            normalized,
+            finalScore,
             (int)(GameConfig.QUICK_MATH_DURATION_MS / 1000),
             true);
         
         Intent intent = new Intent(this, ResultActivity.class);
-        intent.putExtra(Constants.INTENT_SCORE, normalized);
+        intent.putExtra(Constants.INTENT_SCORE, finalScore);
         intent.putExtra(Constants.INTENT_TIME, (int)(GameConfig.QUICK_MATH_DURATION_MS / 1000));
         intent.putExtra(Constants.INTENT_TYPE, Constants.TYPE_QUICK_MATH);
         startActivity(intent);
@@ -222,12 +219,9 @@ public class QuickMathActivity extends AppCompatActivity {
             gameTimer = null;
         }
         pauseTimestamp = System.currentTimeMillis();
-        int normalized = questionCount > 0
-                ? Math.round((float) currentScore / questionCount
-                        * GameConfig.SCORE_NORMALIZATION_SCALE)
-                : 0;
+        int finalScore = currentScore;
         analytics.logGameEnd(GameType.MATH,
-            normalized,
+            finalScore,
             (int)(GameConfig.QUICK_MATH_DURATION_MS / 1000),
             false);
     }

--- a/app/src/main/java/com/gigamind/cognify/util/GameConfig.java
+++ b/app/src/main/java/com/gigamind/cognify/util/GameConfig.java
@@ -12,8 +12,6 @@ public final class GameConfig {
     // Max time considered for full points in Quick Math
     public static final long MAX_RESPONSE_TIME_MS = 5_000;
 
-    // Scale factor used when normalizing Quick Math scores
-    public static final int SCORE_NORMALIZATION_SCALE = 10;
 
     // Word game settings
     public static final int MIN_WORD_LENGTH = 3;

--- a/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
@@ -59,8 +59,8 @@ public class MathGameEngineTest {
 
         int difficulty = engine.getCurrentDifficulty();
         int base = GameConfig.BASE_SCORE * difficulty * difficulty;
-        // At 0 ms response time, points are doubled
-        assertEquals(base * 2, engine.getScore(true, 0));
+        int expectedFast = base + GameConfig.LENGTH_BONUS * difficulty;
+        assertEquals(expectedFast, engine.getScore(true, 0));
         assertEquals(-5, engine.getScore(false, 0));
 
         // After MAX_RESPONSE_TIME_MS, base points are awarded


### PR DESCRIPTION
## Summary
- revise `ExponentialMathScoreStrategy` to mirror Word Dash scoring
- drop Quick Math score normalisation and use raw total
- remove unused score normalisation constant
- update documentation
- adjust unit tests for new formula

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68533221878883328e4cb6a74f66064b