### PR TITLE
Balance scoring between games

### DIFF
--- a/SCORING.md
+++ b/SCORING.md
@@ -29,7 +29,7 @@ if wrong:
     score = -5
 else:
     diffFactor = difficulty
-    base = BASE_SCORE * diffFactor^2
+    base = (BASE_SCORE / 2) * diffFactor^2 + (BASE_SCORE / 2)
     bonus = LENGTH_BONUS * diffFactor
             * (MAX_RESPONSE_TIME_MS - responseTime) / MAX_RESPONSE_TIME_MS
     score = round(base + bonus)

--- a/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialMathScoreStrategy.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialMathScoreStrategy.java
@@ -17,7 +17,10 @@ public class ExponentialMathScoreStrategy implements MathScoreStrategy {
         }
 
         int diffFactor = difficulty;
-        int base = GameConfig.BASE_SCORE * diffFactor * diffFactor;
+        // Mirror the tempered quadratic growth used in the word game so that
+        // questions across all operations award comparable points.
+        int base = (GameConfig.BASE_SCORE / 2) * diffFactor * diffFactor
+                + (GameConfig.BASE_SCORE / 2);
         long clamped = Math.min(responseTimeMs, GameConfig.MAX_RESPONSE_TIME_MS);
 
         double bonusFactor = (double) (GameConfig.MAX_RESPONSE_TIME_MS - clamped)

--- a/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
@@ -58,7 +58,8 @@ public class MathGameEngineTest {
         assertFalse(engine.checkAnswer(correct + 1));
 
         int difficulty = engine.getCurrentDifficulty();
-        int base = GameConfig.BASE_SCORE * difficulty * difficulty;
+        int base = (GameConfig.BASE_SCORE / 2) * difficulty * difficulty
+                + (GameConfig.BASE_SCORE / 2);
         int expectedFast = base + GameConfig.LENGTH_BONUS * difficulty;
         assertEquals(expectedFast, engine.getScore(true, 0));
         assertEquals(-5, engine.getScore(false, 0));


### PR DESCRIPTION
## Summary
- adjust Quick Math scoring formula so base score mirrors Word Dash approach
- update docs and tests accordingly
- clarify comment that fairness applies across all math operations

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*


------
https://chatgpt.com/codex/tasks/task_e_685334b514108332a68db9dbffc599f1