### PR TITLE
Enhance gameplay with additional sound effects

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/OnboardingActivity.java
@@ -114,6 +114,7 @@ public class OnboardingActivity extends BaseActivity {
             @Override
             public void onPageSelected(int position) {
                 analytics.logOnboardingPage(position);
+                SoundManager.getInstance(OnboardingActivity.this).playSwipe();
             }
         });
 

--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -69,7 +69,10 @@ public class QuickMathActivity extends BaseActivity {
         equationText = findViewById(R.id.equationText);
         closeGame = findViewById(R.id.close_game);
 
-        closeGame.setOnClickListener(view -> showExitDialog());
+        closeGame.setOnClickListener(view -> {
+            SoundManager.getInstance(this).playPop();
+            showExitDialog();
+        });
         
         answerButtons = new MaterialButton[4];
         answerButtons[0] = findViewById(R.id.answer1Button);
@@ -86,7 +89,10 @@ public class QuickMathActivity extends BaseActivity {
         // Set up click listeners for answer buttons
         for (int i = 0; i < answerButtons.length; i++) {
             final int index = i;
-            answerButtons[i].setOnClickListener(v -> checkAnswer(index));
+            answerButtons[i].setOnClickListener(v -> {
+                SoundManager.getInstance(this).playButton();
+                checkAnswer(index);
+            });
         }
 
         tutorialHelper = new TutorialHelper(this);

--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -83,6 +83,10 @@ public class ResultActivity extends BaseActivity {
         finalGameType = getIntent().getStringExtra(INTENT_TYPE);
         int wordsFound = getIntent().getIntExtra(INTENT_FOUND_WORDS, 0);
 
+        if (finalScore <= 0) {
+            SoundManager.getInstance(this).playLose();
+        }
+
         // (1) Compute how much XP was earned (PB + streak bonus)
         int xpEarned = calculateXpEarned(finalScore, finalGameType);
 
@@ -386,6 +390,7 @@ public class ResultActivity extends BaseActivity {
 
     private void setupButtons(String gameType) {
         playAgainButton.setOnClickListener(v -> {
+            SoundManager.getInstance(this).playButton();
             Class<?> cls = gameType.equals(Constants.TYPE_QUICK_MATH)
                     ? QuickMathActivity.class
                     : WordDashActivity.class;
@@ -395,13 +400,17 @@ public class ResultActivity extends BaseActivity {
         });
 
         homeButton.setOnClickListener(v -> {
+            SoundManager.getInstance(this).playButton();
             Intent homeIntent = new Intent(this, MainActivity.class);
             homeIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(homeIntent);
             finish();
         });
 
-        challengeButton.setOnClickListener(v -> shareChallenge());
+        challengeButton.setOnClickListener(v -> {
+            SoundManager.getInstance(this).playButton();
+            shareChallenge();
+        });
     }
 
     @Override

--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -166,7 +166,10 @@ public class WordDashActivity extends BaseActivity {
         loadingIndicator = findViewById(R.id.loadingIndicator);
         closeGame = findViewById(R.id.close_game);
 
-        closeGame.setOnClickListener(view -> showExitDialog());
+        closeGame.setOnClickListener(view -> {
+            SoundManager.getInstance(this).playPop();
+            showExitDialog();
+        });
     }
 
     private void setupButtons() {
@@ -174,9 +177,18 @@ public class WordDashActivity extends BaseActivity {
         clearButton = findViewById(R.id.clearButton);
         backspaceButton = findViewById(R.id.backspaceButton);
 
-        submitButton.setOnClickListener(v -> submitWord());
-        clearButton.setOnClickListener(v -> clearWord());
-        backspaceButton.setOnClickListener(this::handleBackspace);
+        submitButton.setOnClickListener(v -> {
+            SoundManager.getInstance(this).playButton();
+            submitWord();
+        });
+        clearButton.setOnClickListener(v -> {
+            SoundManager.getInstance(this).playButton();
+            clearWord();
+        });
+        backspaceButton.setOnClickListener(v -> {
+            SoundManager.getInstance(this).playButton();
+            handleBackspace(v);
+        });
     }
 
     private void observeGameState() {
@@ -237,6 +249,7 @@ public class WordDashActivity extends BaseActivity {
                     v.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
                 }
                 animateButtonPress(button);
+                SoundManager.getInstance(this).playBounce();
                 onLetterClick(letters[index]);
             });
 

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -202,6 +202,7 @@ public class HomeFragment extends Fragment {
             if (areAnimationsEnabled()) {
                 AnimationUtils.bounce(v);
             }
+            SoundManager.getInstance(requireContext()).playButton();
             handleGameLaunch(v);
         };
 
@@ -214,6 +215,7 @@ public class HomeFragment extends Fragment {
         cardView.setOnClickListener(animatedClickListener);
 
         currentUserAvatar.setOnClickListener(v -> {
+            SoundManager.getInstance(requireContext()).playButton();
             BottomNavigationView bottomNav = requireActivity().findViewById(R.id.bottomNavigation);
             bottomNav.setSelectedItemId(R.id.navigation_profile);
         });

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -101,6 +101,7 @@ public class SettingsFragment extends Fragment {
 
     private void setupButtons() {
         binding.replayTutorialButton.setOnClickListener(v -> {
+            SoundManager.getInstance(requireContext()).playButton();
             new MaterialAlertDialogBuilder(requireContext())
                     .setTitle(R.string.replay_tutorial)
                     .setMessage(R.string.replay_tutorial_confirm)
@@ -114,6 +115,7 @@ public class SettingsFragment extends Fragment {
         });
 
         binding.resetProgressButton.setOnClickListener(v -> {
+            SoundManager.getInstance(requireContext()).playButton();
             new MaterialAlertDialogBuilder(requireContext())
                     .setTitle(R.string.reset_progress)
                     .setMessage(R.string.reset_progress_confirm)
@@ -129,6 +131,7 @@ public class SettingsFragment extends Fragment {
         });
 
         binding.deleteAccountButton.setOnClickListener(v -> {
+            SoundManager.getInstance(requireContext()).playButton();
             new MaterialAlertDialogBuilder(requireContext())
                     .setTitle(R.string.delete_account)
                     .setMessage(R.string.delete_account_confirm)
@@ -143,6 +146,7 @@ public class SettingsFragment extends Fragment {
         if (service.isUserSignedIn()) {
             binding.btnSignIn.setText(R.string.sign_out);
             binding.btnSignIn.setOnClickListener(v -> {
+                SoundManager.getInstance(requireContext()).playButton();
                 new MaterialAlertDialogBuilder(requireContext())
                         .setTitle(R.string.logout_confirm_title)
                         .setMessage(R.string.logout_confirm_message)
@@ -172,6 +176,7 @@ public class SettingsFragment extends Fragment {
         } else {
             binding.btnSignIn.setText(R.string.sign_in);
             binding.btnSignIn.setOnClickListener(v -> {
+                SoundManager.getInstance(requireContext()).playButton();
                 // Start sign in flow
                 startActivity(new Intent(requireContext(), OnboardingActivity.class));
             });

--- a/app/src/main/java/com/gigamind/cognify/util/SoundManager.java
+++ b/app/src/main/java/com/gigamind/cognify/util/SoundManager.java
@@ -24,6 +24,10 @@ public class SoundManager {
     private final int correctSoundId;
     private final int wrongSoundId;
     private final int heartbeatSoundId;
+    private final int bounceSoundId;
+    private final int popSoundId;
+    private final int swipeSoundId;
+    private final int loseSoundId;
     // Reuse existing sounds for additional cues
     private final int toggleSoundId;
     private final int milestoneSoundId;
@@ -63,6 +67,18 @@ public class SoundManager {
 
         heartbeatSoundId = soundPool.load(context, R.raw.heartbeat, 1);
         loadedMap.put(heartbeatSoundId, false);
+
+        bounceSoundId = soundPool.load(context, R.raw.button_bounce, 1);
+        loadedMap.put(bounceSoundId, false);
+
+        popSoundId = soundPool.load(context, R.raw.dialog_pop, 1);
+        loadedMap.put(popSoundId, false);
+
+        swipeSoundId = soundPool.load(context, R.raw.swipe_sound, 1);
+        loadedMap.put(swipeSoundId, false);
+
+        loseSoundId = soundPool.load(context, R.raw.lose_sound, 1);
+        loadedMap.put(loseSoundId, false);
 
         // For toggles and milestone cues we simply reuse existing files
         toggleSoundId = buttonSoundId;
@@ -107,6 +123,26 @@ public class SoundManager {
 
     public void playHeartbeat() {
         playSound(heartbeatSoundId);
+    }
+
+    /** Plays a bouncy click for letter presses */
+    public void playBounce() {
+        playSound(bounceSoundId);
+    }
+
+    /** Subtle pop used when showing dialogs */
+    public void playPop() {
+        playSound(popSoundId);
+    }
+
+    /** Swipe cue for onboarding pages */
+    public void playSwipe() {
+        playSound(swipeSoundId);
+    }
+
+    /** Sad trombone when the player scores zero */
+    public void playLose() {
+        playSound(loseSoundId);
     }
 
     /** Plays a short click sound for toggle switches */


### PR DESCRIPTION
## Summary
- expand `SoundManager` to support new audio cues
- add button and pop sounds in Word Dash and Quick Math
- play swipe sound during onboarding slides
- trigger sound on home and settings actions
- play lose sound on zero‑score results

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68533f5eae148332b8c4d14b92f326fa