### PR TITLE
Fix repeated heartbeat sound

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -42,6 +42,7 @@ public class QuickMathActivity extends BaseActivity {
     private boolean questionAnswered;
     private long timeRemaining;
     private long pauseTimestamp;
+    private boolean finalCountdownPlayed = false;
     private TutorialHelper tutorialHelper;
     private boolean tutorialActive = false;
     private TutorialOverlay tutorialOverlay;
@@ -145,8 +146,9 @@ public class QuickMathActivity extends BaseActivity {
                     public void onTick(long millisRemaining) {
                         timeRemaining = millisRemaining;
                         timerText.setText(String.valueOf(millisRemaining / 1000));
-                        if (millisRemaining <= GameConfig.FINAL_COUNTDOWN_MS) {
+                        if (millisRemaining <= GameConfig.FINAL_COUNTDOWN_MS && !finalCountdownPlayed) {
                             triggerFinalCountdown();
+                            finalCountdownPlayed = true;
                         }
                     }
 
@@ -222,6 +224,7 @@ public class QuickMathActivity extends BaseActivity {
     }
 
     private void startGame() {
+        finalCountdownPlayed = false;
         startGameTimer();
         nextQuestion();
     }

--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -69,6 +69,7 @@ public class WordDashActivity extends BaseActivity {
     private View loadingIndicator;
     private long timeRemaining = GameConfig.WORD_DASH_DURATION_MS;
     private long pauseTimestamp;
+    private boolean finalCountdownPlayed = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -363,6 +364,7 @@ public class WordDashActivity extends BaseActivity {
 
     private void startGame() {
         timeRemaining = GameConfig.WORD_DASH_DURATION_MS;
+        finalCountdownPlayed = false;
         gameStateManager.startGame(timeRemaining);
         startGameTimer();
     }
@@ -379,8 +381,9 @@ public class WordDashActivity extends BaseActivity {
                     public void onTick(long millisRemaining) {
                         timeRemaining = millisRemaining;
                         gameStateManager.updateTimeRemaining(millisRemaining);
-                        if (millisRemaining <= GameConfig.FINAL_COUNTDOWN_MS) {
+                        if (millisRemaining <= GameConfig.FINAL_COUNTDOWN_MS && !finalCountdownPlayed) {
                             triggerFinalCountdown();
+                            finalCountdownPlayed = true;
                         }
                     }
 


### PR DESCRIPTION
## Summary
- prevent repeating the heartbeat sound when the timer is under 10s
- reset the countdown flag when a new game starts

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685343748a1083329937df39e00c24e3