### PR TITLE
Add per-game tutorial tracking

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -13,6 +13,7 @@ import com.gigamind.cognify.ui.MainActivity;
 import com.gigamind.cognify.util.GameConfig;
 import com.gigamind.cognify.util.GameTimer;
 import com.gigamind.cognify.util.TutorialHelper;
+import com.gigamind.cognify.util.GameType;
 import com.gigamind.cognify.ui.TutorialOverlay;
 
 import com.gigamind.cognify.ui.BaseActivity;
@@ -22,7 +23,6 @@ import com.gigamind.cognify.engine.MathGameEngine;
 import com.gigamind.cognify.util.Constants;
 import com.google.android.material.button.MaterialButton;
 import com.gigamind.cognify.analytics.GameAnalytics;
-import com.gigamind.cognify.util.GameType;
 import com.gigamind.cognify.util.SoundManager;
 
 import java.util.List;
@@ -95,7 +95,7 @@ public class QuickMathActivity extends BaseActivity {
             });
         }
 
-        tutorialHelper = new TutorialHelper(this);
+        tutorialHelper = new TutorialHelper(this, GameType.MATH);
 
         disableGameInteractions();
         if (!tutorialHelper.isTutorialCompleted()) {

--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -87,7 +87,7 @@ public class WordDashActivity extends BaseActivity {
         analytics.logScreenView(Constants.ANALYTICS_SCREEN_WORD_DASH);
         analytics.logGameStart(GameType.WORD);
 
-        tutorialHelper = new TutorialHelper(this);
+        tutorialHelper = new TutorialHelper(this, GameType.WORD);
 
         SharedPreferences prefs = getSharedPreferences(Constants.PREF_APP, MODE_PRIVATE);
         hapticsEnabled = prefs.getBoolean(Constants.PREF_HAPTICS_ENABLED, true);

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -39,7 +39,7 @@ public class SettingsFragment extends Fragment {
     private static final String KEY_HAPTICS_ENABLED = Constants.PREF_HAPTICS_ENABLED;
     private static final String KEY_ANIMATIONS_ENABLED = Constants.PREF_ANIMATIONS_ENABLED;
     private static final String KEY_DARK_MODE_ENABLED = Constants.PREF_DARK_MODE_ENABLED;
-    private static final String KEY_TUTORIAL_COMPLETED = Constants.PREF_TUTORIAL_COMPLETED;
+    private static final String KEY_ONBOARDING_COMPLETED = Constants.PREF_ONBOARDING_COMPLETED;
 
     @Nullable
     @Override
@@ -106,7 +106,7 @@ public class SettingsFragment extends Fragment {
                     .setTitle(R.string.replay_tutorial)
                     .setMessage(R.string.replay_tutorial_confirm)
                     .setPositiveButton(R.string.yes, (dialog, which) -> {
-                        prefs.edit().putBoolean(KEY_TUTORIAL_COMPLETED, false).apply();
+                        prefs.edit().putBoolean(KEY_ONBOARDING_COMPLETED, false).apply();
                         startActivity(new Intent(requireContext(), OnboardingActivity.class));
                         requireActivity().finish();
                     })
@@ -123,7 +123,7 @@ public class SettingsFragment extends Fragment {
                         // Clear all preferences except tutorial completion
                         SharedPreferences.Editor editor = prefs.edit();
                         editor.clear();
-                        editor.putBoolean(KEY_TUTORIAL_COMPLETED, true);
+                        editor.putBoolean(KEY_ONBOARDING_COMPLETED, true);
                         editor.apply();
                     })
                     .setNegativeButton(R.string.no, null)

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -25,6 +25,7 @@ import com.gigamind.cognify.ui.WordDashActivity;
 import com.gigamind.cognify.util.Constants;
 import com.gigamind.cognify.util.AvatarLoader;
 import com.gigamind.cognify.util.TutorialHelper;
+import com.gigamind.cognify.util.GameType;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.button.MaterialButton;
 import com.gigamind.cognify.data.firebase.FirebaseService;
@@ -72,7 +73,7 @@ public class WordDashFragment extends Fragment {
         prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
         com.gigamind.cognify.animation.AnimatorProvider.updateFromPreferences(requireContext());
         userRepository = new UserRepository(requireContext());
-        tutorialHelper = new TutorialHelper(requireContext());
+        tutorialHelper = new TutorialHelper(requireContext(), GameType.WORD);
 
         // Check signed-in user
         firebaseUser = FirebaseService.getInstance().getCurrentUser();

--- a/app/src/main/java/com/gigamind/cognify/util/Constants.java
+++ b/app/src/main/java/com/gigamind/cognify/util/Constants.java
@@ -26,7 +26,10 @@ public class Constants {
     public static final String PREF_IS_GUEST = "is_guest_mode";
     public static final String PREF_NOTIFICATION = "notification_preferences";
     public static final String PREF_NOTIFICATION_ENABLED = "notifications_enabled";
-    public static final String PREF_TUTORIAL_COMPLETED = "tutorial_completed";
+    // Marks that the onboarding tutorial has been completed
+    public static final String PREF_ONBOARDING_COMPLETED = "tutorial_completed";
+    // Prefix for per-game tutorial completion flags
+    public static final String PREF_TUTORIAL_COMPLETED_PREFIX = "game_tutorial_completed_";
     public static final String PREF_SOUND_ENABLED = "sound_enabled";
     public static final String PREF_HAPTICS_ENABLED = "haptics_enabled";
     public static final String PREF_ANIMATIONS_ENABLED = "animations_enabled";

--- a/app/src/main/java/com/gigamind/cognify/util/TutorialHelper.java
+++ b/app/src/main/java/com/gigamind/cognify/util/TutorialHelper.java
@@ -3,27 +3,31 @@ package com.gigamind.cognify.util;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import com.gigamind.cognify.util.GameType;
+
 /**
- * Helper for managing the first-time Word Dash tutorial state.
+ * Helper for managing the first-time tutorial state for each game type.
  */
 public class TutorialHelper {
     private final SharedPreferences prefs;
+    private final String key;
 
-    public TutorialHelper(Context context) {
+    public TutorialHelper(Context context, GameType type) {
         this.prefs = context.getSharedPreferences(Constants.PREF_APP, Context.MODE_PRIVATE);
+        this.key = Constants.PREF_TUTORIAL_COMPLETED_PREFIX + type.id();
     }
 
     /**
      * Returns true if the user already completed the tutorial.
      */
     public boolean isTutorialCompleted() {
-        return prefs.getBoolean(Constants.PREF_TUTORIAL_COMPLETED, false);
+        return prefs.getBoolean(key, false);
     }
 
     /**
      * Marks the tutorial as completed.
      */
     public void markTutorialCompleted() {
-        prefs.edit().putBoolean(Constants.PREF_TUTORIAL_COMPLETED, true).apply();
+        prefs.edit().putBoolean(key, true).apply();
     }
 }

--- a/app/src/test/java/com/gigamind/cognify/util/ConstantsTest.java
+++ b/app/src/test/java/com/gigamind/cognify/util/ConstantsTest.java
@@ -16,6 +16,6 @@ public class ConstantsTest {
     void testPreferences() {
         assertNotNull(Constants.PREFS_NAME);
         assertNotNull(Constants.PREF_APP);
-        assertEquals("tutorial_completed", Constants.PREF_TUTORIAL_COMPLETED);
+        assertEquals("tutorial_completed", Constants.PREF_ONBOARDING_COMPLETED);
     }
 }


### PR DESCRIPTION
## Summary
- handle onboarding and per-game tutorials separately
- track tutorial completion with game-specific keys
- initialize TutorialHelper with a `GameType`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68534446b9248332a84144c4f5d14716