### PR TITLE
Add analytics logging across app

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/MainActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/MainActivity.java
@@ -49,6 +49,20 @@ public class MainActivity extends BaseActivity {
 
         bottomNavigation.setOnItemSelectedListener(item -> {
             SoundManager.getInstance(this).playButton();
+            switch (item.getItemId()) {
+                case R.id.navigation_home:
+                    analytics.logButtonClick("nav_home");
+                    break;
+                case R.id.navigation_leaderboard:
+                    analytics.logButtonClick("nav_leaderboard");
+                    break;
+                case R.id.navigation_profile:
+                    analytics.logButtonClick("nav_profile");
+                    break;
+                case R.id.navigation_settings:
+                    analytics.logButtonClick("nav_settings");
+                    break;
+            }
             return NavigationUI.onNavDestinationSelected(item, navController);
         });
     }

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -31,6 +31,7 @@ import android.graphics.Color;
 import android.content.res.ColorStateList;
 
 import com.gigamind.cognify.util.SoundManager;
+import com.gigamind.cognify.analytics.GameAnalytics;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.snackbar.Snackbar;
@@ -62,6 +63,7 @@ public class HomeFragment extends Fragment {
     private UserRepository userRepository;
     private FirebaseUser firebaseUser;
     private ListenerRegistration homeListener;
+    private GameAnalytics analytics;
 
     @Nullable
     @Override
@@ -82,6 +84,9 @@ public class HomeFragment extends Fragment {
 
         // Initialize views
         initializeViews();
+
+        analytics = GameAnalytics.getInstance(requireContext());
+        analytics.logScreenView(Constants.ANALYTICS_SCREEN_HOME);
 
         // Initialize SharedPreferences and UserRepository
         prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE);
@@ -218,6 +223,7 @@ public class HomeFragment extends Fragment {
 
         currentUserAvatar.setOnClickListener(v -> {
             SoundManager.getInstance(requireContext()).playButton();
+            analytics.logButtonClick("open_profile_avatar");
             BottomNavigationView bottomNav = requireActivity().findViewById(R.id.bottomNavigation);
             bottomNav.setSelectedItemId(R.id.navigation_profile);
         });
@@ -241,11 +247,14 @@ public class HomeFragment extends Fragment {
         boolean openWordDash;
         if (v.getId() == R.id.wordGameCard || v == binding.wordGameCard.playButton) {
             openWordDash = true;
+            analytics.logButtonClick(isDaily ? "play_word_dash_daily" : "play_word_dash");
         } else if (v.getId() == R.id.mathGameCard || v == binding.mathGameCard.playButton) {
             openWordDash = false;
+            analytics.logButtonClick(isDaily ? "play_quick_math_daily" : "play_quick_math");
         } else {
             // Daily challenge card or title - follow today's designated game
             openWordDash = isWordDay;
+            analytics.logButtonClick("play_daily_challenge");
         }
 
         Intent intent;

--- a/app/src/main/java/com/gigamind/cognify/ui/leaderboard/LeaderboardFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/leaderboard/LeaderboardFragment.java
@@ -16,6 +16,8 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import com.gigamind.cognify.data.firebase.FirebaseService;
 import com.gigamind.cognify.databinding.FragmentLeaderboardBinding;
 import com.gigamind.cognify.ui.OnboardingActivity;
+import com.gigamind.cognify.analytics.GameAnalytics;
+import com.gigamind.cognify.util.Constants;
 
 /**
  * A fragment that displays the top‐100 leaderboard.  If the user is not signed in,
@@ -27,6 +29,7 @@ public class LeaderboardFragment extends Fragment {
     private LeaderboardAdapter adapter;
     private FirebaseService firebaseService;
     private LeaderboardViewModel viewModel;
+    private GameAnalytics analytics;
 
     @Nullable
     @Override
@@ -46,6 +49,8 @@ public class LeaderboardFragment extends Fragment {
 
         firebaseService = FirebaseService.getInstance();
         viewModel = new ViewModelProvider(this).get(LeaderboardViewModel.class);
+        analytics = GameAnalytics.getInstance(requireContext());
+        analytics.logScreenView(Constants.ANALYTICS_SCREEN_LEADERBOARD);
 
         setupRecyclerView();
         setupListeners();
@@ -63,6 +68,7 @@ public class LeaderboardFragment extends Fragment {
         // Pull‐to‐refresh always forces a refresh.
         binding.swipeRefresh.setOnRefreshListener(() -> {
             if (firebaseService.isUserSignedIn()) {
+                analytics.logButtonClick("refresh_leaderboard");
                 viewModel.refresh();
             } else {
                 binding.swipeRefresh.setRefreshing(false);
@@ -71,11 +77,13 @@ public class LeaderboardFragment extends Fragment {
 
         // Retry button in case of error:
         binding.retryButton.setOnClickListener(v -> {
+            analytics.logButtonClick("retry_leaderboard");
             checkAndLoad();
         });
 
         // If user taps “Sign In,” we send them to OnboardingActivity (or your login screen)
         binding.signInButton.setOnClickListener(v -> {
+            analytics.logButtonClick("signin_leaderboard");
             startActivity(new Intent(requireContext(), OnboardingActivity.class));
         });
     }

--- a/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/profile/ProfileFragment.java
@@ -27,6 +27,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.ListenerRegistration;
+import com.gigamind.cognify.analytics.GameAnalytics;
 
 import java.text.DateFormat;
 import java.util.Date;
@@ -54,6 +55,7 @@ public class ProfileFragment extends Fragment {
     private UserRepository userRepository;
     private FirebaseUser firebaseUser;
     private ListenerRegistration userDocListener;
+    private GameAnalytics analytics;
 
     @Nullable
     @Override
@@ -88,6 +90,8 @@ public class ProfileFragment extends Fragment {
         // 2) Initialize FirebaseUser & UserRepository
         firebaseUser   = FirebaseService.getInstance().getCurrentUser();
         userRepository = new UserRepository(requireContext());
+        analytics = GameAnalytics.getInstance(requireContext());
+        analytics.logScreenView(Constants.ANALYTICS_SCREEN_PROFILE);
 
         // 3) Populate static profile info (name, email, joined date)
         populateUserInfo();
@@ -183,11 +187,13 @@ public class ProfileFragment extends Fragment {
     private void setupClickListeners() {
         // (Alternatively, open a real SettingsActivity)
         settingsIcon.setOnClickListener(v -> {
+            analytics.logButtonClick("open_settings_from_profile");
             BottomNavigationView bottomNav = requireActivity().findViewById(R.id.bottomNavigation);
             bottomNav.setSelectedItemId(R.id.navigation_settings);
         });
 
         inviteFriendsButton.setOnClickListener(v -> {
+            analytics.logButtonClick("invite_friends");
             Intent shareIntent = new Intent(Intent.ACTION_SEND);
             shareIntent.setType("text/plain");
             String friendCode = (firebaseUser != null) ? firebaseUser.getUid() : "guest";
@@ -198,6 +204,7 @@ public class ProfileFragment extends Fragment {
 
 
         shareStreakButton.setOnClickListener(v -> {
+            analytics.logButtonClick("share_streak");
             int streak = userRepository.getCurrentStreak();
             Intent intent = new Intent(Intent.ACTION_SEND);
             intent.setType("text/plain");
@@ -207,10 +214,12 @@ public class ProfileFragment extends Fragment {
         });
 
         trophyRoomButton.setOnClickListener(v -> {
+            analytics.logButtonClick("open_trophy_room");
             Intent intent = new Intent(requireContext(), com.gigamind.cognify.ui.trophy.TrophyRoomActivity.class);
             startActivity(intent);
         });
         profileAvatar.setOnClickListener(v -> {
+            analytics.logButtonClick("edit_avatar");
             Intent intent = new Intent(requireContext(), com.gigamind.cognify.ui.avatar.AvatarMakerActivity.class);
             startActivity(intent);
         });

--- a/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/settings/SettingsFragment.java
@@ -25,6 +25,8 @@ import com.gigamind.cognify.util.SoundManager;
 import com.gigamind.cognify.util.GoogleSignInHelper;
 import android.widget.Toast;
 
+import com.gigamind.cognify.analytics.GameAnalytics;
+
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.FirebaseUser;
@@ -40,6 +42,7 @@ public class SettingsFragment extends Fragment {
     private static final String KEY_ANIMATIONS_ENABLED = Constants.PREF_ANIMATIONS_ENABLED;
     private static final String KEY_DARK_MODE_ENABLED = Constants.PREF_DARK_MODE_ENABLED;
     private static final String KEY_ONBOARDING_COMPLETED = Constants.PREF_ONBOARDING_COMPLETED;
+    private GameAnalytics analytics;
 
     @Nullable
     @Override
@@ -53,6 +56,8 @@ public class SettingsFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         prefs = requireActivity().getSharedPreferences(Constants.PREF_APP, 0);
+        analytics = GameAnalytics.getInstance(requireContext());
+        analytics.logScreenView(Constants.ANALYTICS_SCREEN_SETTINGS);
         com.gigamind.cognify.animation.AnimatorProvider.updateFromPreferences(requireContext());
         setupPreferences();
         setupButtons();
@@ -75,17 +80,20 @@ public class SettingsFragment extends Fragment {
         binding.soundEffectsSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
                 prefs.edit().putBoolean(KEY_SOUND_ENABLED, isChecked).apply();
                 SoundManager.getInstance(requireContext()).playToggle();
+                analytics.logButtonClick("toggle_sound" + (isChecked ? "_on" : "_off"));
         });
 
         binding.hapticsSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
                 prefs.edit().putBoolean(KEY_HAPTICS_ENABLED, isChecked).apply();
                 SoundManager.getInstance(requireContext()).playToggle();
+                analytics.logButtonClick("toggle_haptics" + (isChecked ? "_on" : "_off"));
         });
 
         binding.animationsSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
                 prefs.edit().putBoolean(KEY_ANIMATIONS_ENABLED, isChecked).apply();
                 com.gigamind.cognify.animation.AnimatorProvider.setAnimationsEnabled(isChecked);
                 SoundManager.getInstance(requireContext()).playToggle();
+                analytics.logButtonClick("toggle_animations" + (isChecked ? "_on" : "_off"));
         });
 
         binding.darkModeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
@@ -96,12 +104,14 @@ public class SettingsFragment extends Fragment {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
             }
             SoundManager.getInstance(requireContext()).playToggle();
+            analytics.logButtonClick("toggle_dark_mode" + (isChecked ? "_on" : "_off"));
         });
     }
 
     private void setupButtons() {
         binding.replayTutorialButton.setOnClickListener(v -> {
             SoundManager.getInstance(requireContext()).playButton();
+            analytics.logButtonClick("replay_tutorial");
             new MaterialAlertDialogBuilder(requireContext())
                     .setTitle(R.string.replay_tutorial)
                     .setMessage(R.string.replay_tutorial_confirm)
@@ -116,6 +126,7 @@ public class SettingsFragment extends Fragment {
 
         binding.resetProgressButton.setOnClickListener(v -> {
             SoundManager.getInstance(requireContext()).playButton();
+            analytics.logButtonClick("reset_progress");
             new MaterialAlertDialogBuilder(requireContext())
                     .setTitle(R.string.reset_progress)
                     .setMessage(R.string.reset_progress_confirm)
@@ -132,6 +143,7 @@ public class SettingsFragment extends Fragment {
 
         binding.deleteAccountButton.setOnClickListener(v -> {
             SoundManager.getInstance(requireContext()).playButton();
+            analytics.logButtonClick("delete_account");
             new MaterialAlertDialogBuilder(requireContext())
                     .setTitle(R.string.delete_account)
                     .setMessage(R.string.delete_account_confirm)
@@ -147,6 +159,7 @@ public class SettingsFragment extends Fragment {
             binding.btnSignIn.setText(R.string.sign_out);
             binding.btnSignIn.setOnClickListener(v -> {
                 SoundManager.getInstance(requireContext()).playButton();
+                analytics.logButtonClick("sign_out");
                 new MaterialAlertDialogBuilder(requireContext())
                         .setTitle(R.string.logout_confirm_title)
                         .setMessage(R.string.logout_confirm_message)
@@ -177,6 +190,7 @@ public class SettingsFragment extends Fragment {
             binding.btnSignIn.setText(R.string.sign_in);
             binding.btnSignIn.setOnClickListener(v -> {
                 SoundManager.getInstance(requireContext()).playButton();
+                analytics.logButtonClick("sign_in");
                 // Start sign in flow
                 startActivity(new Intent(requireContext(), OnboardingActivity.class));
             });

--- a/app/src/main/java/com/gigamind/cognify/util/Constants.java
+++ b/app/src/main/java/com/gigamind/cognify/util/Constants.java
@@ -48,6 +48,10 @@ public class Constants {
     public static final String ANALYTICS_SCREEN_RESULT = "result_screen";
     public static final String ANALYTICS_SCREEN_WORD_DASH = "word_dash_game";
     public static final String ANALYTICS_SCREEN_QUICK_MATH = "quick_math_game";
+    public static final String ANALYTICS_SCREEN_HOME = "home_screen";
+    public static final String ANALYTICS_SCREEN_PROFILE = "profile_screen";
+    public static final String ANALYTICS_SCREEN_LEADERBOARD = "leaderboard_screen";
+    public static final String ANALYTICS_SCREEN_SETTINGS = "settings_screen";
 
     // Avatar customization keys
     public static final String AVATAR_SKIN = "avatar_skin";


### PR DESCRIPTION
## Summary
- extend analytics constants for additional screens
- log screen views and button clicks in HomeFragment
- record screen view and actions in ProfileFragment
- track setting toggles and actions in SettingsFragment
- record leaderboard interactions
- capture navigation events in MainActivity

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853487d66d88332a5fd34447ec95213