### PR TITLE
Improve Quick Math screen aesthetics

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -197,7 +197,7 @@ public class QuickMathActivity extends BaseActivity {
         // Delay before next question to show feedback
         answerButtons[buttonIndex].postDelayed(() -> {
             answerButtons[buttonIndex].setBackgroundTintList(
-                getColorStateList(R.color.button_background)
+                getColorStateList(android.R.color.transparent)
             );
             nextQuestion();
         }, 500);

--- a/app/src/main/res/layout/activity_quick_math.xml
+++ b/app/src/main/res/layout/activity_quick_math.xml
@@ -69,31 +69,41 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="64dp"
         android:text="@string/quick_math_equation_placeholder"
-        android:textColor="@color/white"
-        android:textSize="48sp"
-        android:textStyle="bold"
+        style="@style/TextAppearance.Equation"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/titleBar" />
 
-    <GridLayout
-        android:id="@+id/answersLayout"
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/answerCardView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="64dp"
-        android:columnCount="2"
-        android:rowCount="2"
-        android:orientation="horizontal"
+        android:backgroundTint="@color/card_background"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="2dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/equationText"
-        app:layout_constraintWidth_percent="0.8">
+        app:layout_constraintWidth_percent="0.8"
+        app:strokeColor="@color/white"
+        app:strokeWidth="2dp">
+
+        <GridLayout
+            android:id="@+id/answersLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:columnCount="2"
+            android:rowCount="2"
+            android:orientation="horizontal">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer1Button"
-            style="@style/Button.Answer"
+            style="@style/Button.Letter"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:textSize="24sp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="16dp"
             android:layout_columnWeight="1"
@@ -101,9 +111,10 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer2Button"
-            style="@style/Button.Answer"
+            style="@style/Button.Letter"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:textSize="24sp"
             android:layout_marginStart="8dp"
             android:layout_marginBottom="16dp"
             android:layout_columnWeight="1"
@@ -111,21 +122,25 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer3Button"
-            style="@style/Button.Answer"
+            style="@style/Button.Letter"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:textSize="24sp"
             android:layout_marginEnd="8dp"
             android:layout_columnWeight="1"
             android:layout_rowWeight="1" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/answer4Button"
-            style="@style/Button.Answer"
+            style="@style/Button.Letter"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:textSize="24sp"
             android:layout_marginStart="8dp"
             android:layout_columnWeight="1"
             android:layout_rowWeight="1" />
-    </GridLayout>
+        </GridLayout>
+
+    </com.google.android.material.card.MaterialCardView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -115,6 +115,15 @@
         <item name="android:textSize">24sp</item>
     </style>
 
+    <!-- Large equation text style for Quick Math -->
+    <style name="TextAppearance.Equation" parent="TextAppearance.MaterialComponents.Headline4">
+        <item name="android:textColor">@color/text_primary</item>
+        <item name="android:textSize">48sp</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:letterSpacing">0.025</item>
+        <item name="android:fontFamily">sans-serif</item>
+    </style>
+
     <style name="TextAppearance.Settings" parent="TextAppearance.MaterialComponents.Subtitle1">
         <item name="android:textColor">@color/settings_text</item>
         <item name="android:textSize">24sp</item>


### PR DESCRIPTION
## Summary
- style Quick Math answers with the same look as Word Dash letter buttons
- wrap answer grid in a card container
- use a dedicated text appearance for the equation
- reset answer button background to transparent after each question

## Testing
- `./gradlew test -q` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6853490b24b08332b9cc2fc694c5189e