### PR TITLE
Fix daily challenge completion timing

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -46,6 +46,7 @@ public class QuickMathActivity extends BaseActivity {
     private TutorialHelper tutorialHelper;
     private boolean tutorialActive = false;
     private TutorialOverlay tutorialOverlay;
+    private boolean isDailyChallenge = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -53,6 +54,7 @@ public class QuickMathActivity extends BaseActivity {
         setContentView(R.layout.activity_quick_math);
 
         int challengeScore = getIntent().getIntExtra(Constants.EXTRA_CHALLENGE_SCORE, -1);
+        isDailyChallenge = getIntent().getBooleanExtra(Constants.INTENT_IS_DAILY, false);
         if (challengeScore >= 0) {
             String msg = getString(R.string.challenge_toast, challengeScore);
             View rootView = findViewById(android.R.id.content);
@@ -219,6 +221,7 @@ public class QuickMathActivity extends BaseActivity {
         intent.putExtra(Constants.INTENT_SCORE, finalScore);
         intent.putExtra(Constants.INTENT_TIME, (int)(GameConfig.QUICK_MATH_DURATION_MS / 1000));
         intent.putExtra(Constants.INTENT_TYPE, Constants.TYPE_QUICK_MATH);
+        intent.putExtra(Constants.INTENT_IS_DAILY, isDailyChallenge);
         startActivity(intent);
         finish();
     }

--- a/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/ResultActivity.java
@@ -92,6 +92,8 @@ public class ResultActivity extends BaseActivity {
 
         boolean isDaily = getIntent().getBooleanExtra(Constants.INTENT_IS_DAILY, false);
         if (isDaily) {
+            DailyChallengeManager.markCompleted(this);
+            analytics.logDailyChallengeCompleted(finalGameType, finalScore);
             int bonus = DailyChallengeManager.getTodayPerkXp(this);
             xpEarned += bonus;
             String msg = getString(R.string.perk_format, DailyChallengeManager.getTodayPerk(this));

--- a/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/WordDashActivity.java
@@ -70,6 +70,7 @@ public class WordDashActivity extends BaseActivity {
     private long timeRemaining = GameConfig.WORD_DASH_DURATION_MS;
     private long pauseTimestamp;
     private boolean finalCountdownPlayed = false;
+    private boolean isDailyChallenge = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -77,6 +78,7 @@ public class WordDashActivity extends BaseActivity {
         setContentView(R.layout.activity_word_dash);
 
         int challengeScore = getIntent().getIntExtra(Constants.EXTRA_CHALLENGE_SCORE, -1);
+        isDailyChallenge = getIntent().getBooleanExtra(Constants.INTENT_IS_DAILY, false);
         if (challengeScore >= 0) {
             String msg = getString(R.string.challenge_toast, challengeScore);
             View root = findViewById(android.R.id.content);
@@ -416,6 +418,7 @@ public class WordDashActivity extends BaseActivity {
                 Constants.GAME_TYPE_WORD_DASH);
         intent.putExtra(Constants.INTENT_FOUND_WORDS,
                 foundWordsList.size());
+        intent.putExtra(Constants.INTENT_IS_DAILY, isDailyChallenge);
         startActivity(intent);
         finish();
     }

--- a/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/home/HomeFragment.java
@@ -225,7 +225,7 @@ public class HomeFragment extends Fragment {
 
     /**
      * Decides which game to launch (WordDash or QuickMath) based on the view clicked
-     * and whether it was the daily challenge. Also marks daily challenge complete.
+     * and whether it was the daily challenge.
      */
     private void handleGameLaunch(View v) {
         boolean isDaily = (v.getId() == R.id.welcomeCardView
@@ -258,10 +258,6 @@ public class HomeFragment extends Fragment {
         }
         intent.putExtra(Constants.INTENT_IS_DAILY, isDaily);
         startActivity(intent);
-
-        if (isDaily) {
-            DailyChallengeManager.markCompleted(requireContext());
-        }
     }
 
     private boolean areAnimationsEnabled() {

--- a/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/worddash/WordDashFragment.java
@@ -145,7 +145,7 @@ public class WordDashFragment extends Fragment {
 
     /**
      * Decides which game to launch (WordDash or QuickMath) based on the view clicked
-     * and whether it was the daily challenge. Also marks daily challenge complete.
+     * and whether it was the daily challenge.
      */
     private void handleGameLaunch(View v) {
         boolean isDaily = (v.getId() == R.id.welcomeCardView);
@@ -165,10 +165,6 @@ public class WordDashFragment extends Fragment {
         }
         intent.putExtra(Constants.INTENT_IS_DAILY, isDaily);
         startActivity(intent);
-
-        if (isDaily) {
-            DailyChallengeManager.markCompleted(requireContext());
-        }
     }
 
     private boolean areAnimationsEnabled() {


### PR DESCRIPTION
## Summary
- read daily-challenge flag in both game activities
- forward the flag to the results screen
- mark the challenge complete when showing results and log analytics
- remove premature completion call from home and word dash fragments

## Testing
- `./gradlew test --dry-run` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853494743708332bc0056dc31f26460