### PR TITLE
Fix Quick Math scoring imbalance

### DIFF
--- a/SCORING.md
+++ b/SCORING.md
@@ -26,7 +26,7 @@ grant comparable points. Each answer yields points as follows:
 
 ```
 if wrong:
-    score = -5
+    score = -BASE_SCORE * difficulty
 else:
     diffFactor = difficulty
     base = (BASE_SCORE / 2) * diffFactor^2 + (BASE_SCORE / 2)

--- a/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialMathScoreStrategy.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/scoring/ExponentialMathScoreStrategy.java
@@ -13,7 +13,8 @@ public class ExponentialMathScoreStrategy implements MathScoreStrategy {
     @Override
     public int calculateScore(boolean correct, long responseTimeMs, int difficulty) {
         if (!correct) {
-            return -5;
+            // Penalise wrong answers more heavily based on difficulty
+            return -GameConfig.BASE_SCORE * difficulty;
         }
 
         int diffFactor = difficulty;

--- a/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
@@ -62,7 +62,8 @@ public class MathGameEngineTest {
                 + (GameConfig.BASE_SCORE / 2);
         int expectedFast = base + GameConfig.LENGTH_BONUS * difficulty;
         assertEquals(expectedFast, engine.getScore(true, 0));
-        assertEquals(-5, engine.getScore(false, 0));
+        int expectedPenalty = -GameConfig.BASE_SCORE * difficulty;
+        assertEquals(expectedPenalty, engine.getScore(false, 0));
 
         // After MAX_RESPONSE_TIME_MS, base points are awarded
         assertEquals(base, engine.getScore(true, GameConfig.MAX_RESPONSE_TIME_MS + 1000));


### PR DESCRIPTION
## Summary
- update Quick Math scoring rules in docs
- penalise wrong answers by difficulty
- update unit test expectations

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685351da5d5883328af98c96dd2ef437