### PR TITLE
Increase quick math answer choices

### DIFF
--- a/app/src/main/java/com/gigamind/cognify/engine/MathGameEngine.java
+++ b/app/src/main/java/com/gigamind/cognify/engine/MathGameEngine.java
@@ -82,8 +82,8 @@ public class MathGameEngine {
         currentOptions.clear();
         currentOptions.add(currentAnswer);
         
-        // Generate 3 fake options that are close to the real answer
-        while (currentOptions.size() < 4) {
+        // Generate 5 fake options that are close to the real answer
+        while (currentOptions.size() < 6) {
             int offset = random.nextInt(11) - 5; // -5..5
             int fake = currentAnswer + offset;
             if (fake <= 0 || currentOptions.contains(fake)) continue;

--- a/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
+++ b/app/src/main/java/com/gigamind/cognify/ui/QuickMathActivity.java
@@ -77,11 +77,13 @@ public class QuickMathActivity extends BaseActivity {
             showExitDialog();
         });
         
-        answerButtons = new MaterialButton[4];
+        answerButtons = new MaterialButton[6];
         answerButtons[0] = findViewById(R.id.answer1Button);
         answerButtons[1] = findViewById(R.id.answer2Button);
         answerButtons[2] = findViewById(R.id.answer3Button);
         answerButtons[3] = findViewById(R.id.answer4Button);
+        answerButtons[4] = findViewById(R.id.answer5Button);
+        answerButtons[5] = findViewById(R.id.answer6Button);
 
         // Initialize game
         gameEngine = new MathGameEngine();

--- a/app/src/main/res/layout/activity_quick_math.xml
+++ b/app/src/main/res/layout/activity_quick_math.xml
@@ -79,7 +79,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="16dp"
-            android:columnCount="2"
+            android:columnCount="3"
             android:rowCount="2"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -127,6 +127,26 @@
             android:layout_marginStart="8dp"
             android:layout_columnWeight="1"
             android:layout_rowWeight="1" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/answer5Button"
+            style="@style/Button.Letter.Math"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textSize="24sp"
+            android:layout_marginEnd="8dp"
+            android:layout_rowWeight="1"
+            android:layout_columnWeight="1" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/answer6Button"
+            style="@style/Button.Letter.Math"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textSize="24sp"
+            android:layout_marginStart="8dp"
+            android:layout_rowWeight="1"
+            android:layout_columnWeight="1" />
         </GridLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
+++ b/app/src/test/java/com/gigamind/cognify/engine/MathGameEngineTest.java
@@ -31,10 +31,10 @@ public class MathGameEngineTest {
         assertTrue(answer > 1, "Answer should be at least 2");
 
         List<Integer> options = engine.getOptions();
-        assertEquals(4, options.size(), "There should be four options");
+        assertEquals(6, options.size(), "There should be six options");
 
         Set<Integer> unique = new HashSet<>(options);
-        assertEquals(4, unique.size(), "Options should be unique");
+        assertEquals(6, unique.size(), "Options should be unique");
         assertTrue(options.contains(answer), "Options should contain the correct answer");
     }
 


### PR DESCRIPTION
## Summary
- expand fake answer option generation to six total
- update quick math activity to display six buttons
- tweak the layout to include six answer buttons
- adjust unit test for updated option count

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853541ed3e08332957de953837bf3e6